### PR TITLE
Pass in root view controller to WKWebViewUIDelegate

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -165,7 +165,7 @@
     // viewController would be available now. we attempt to set all possible delegates to it, by default
     NSDictionary* settings = self.commandDelegate.settings;
 
-    self.uiDelegate = [[CDVWKWebViewUIDelegate alloc] initWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]];
+    self.uiDelegate = [[CDVWKWebViewUIDelegate alloc] initWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] viewController:self.viewController];
 
     CDVWKWeakScriptMessageHandler *weakScriptMessageHandler = [[CDVWKWeakScriptMessageHandler alloc] initWithScriptMessageHandler:self];
 

--- a/src/ios/CDVWKWebViewUIDelegate.h
+++ b/src/ios/CDVWKWebViewUIDelegate.h
@@ -22,7 +22,7 @@
 @interface CDVWKWebViewUIDelegate : NSObject <WKUIDelegate>
 
 @property (nonatomic, copy) NSString* title;
-@property (nonatomic) UIViewController* rootViewController;
+@property (nonatomic, weak) UIViewController* rootViewController;
 
 - (instancetype)initWithTitle:(NSString*)title viewController:(UIViewController*)vc;
 

--- a/src/ios/CDVWKWebViewUIDelegate.h
+++ b/src/ios/CDVWKWebViewUIDelegate.h
@@ -22,7 +22,8 @@
 @interface CDVWKWebViewUIDelegate : NSObject <WKUIDelegate>
 
 @property (nonatomic, copy) NSString* title;
+@property (nonatomic) UIViewController* rootViewController;
 
-- (instancetype)initWithTitle:(NSString*)title;
+- (instancetype)initWithTitle:(NSString*)title viewController:(UIViewController*)vc;
 
 @end

--- a/src/ios/CDVWKWebViewUIDelegate.m
+++ b/src/ios/CDVWKWebViewUIDelegate.m
@@ -21,11 +21,12 @@
 
 @implementation CDVWKWebViewUIDelegate
 
-- (instancetype)initWithTitle:(NSString*)title
+- (instancetype)initWithTitle:(NSString*)title viewController:(UIViewController *)vc
 {
     self = [super init];
     if (self) {
         self.title = title;
+        self.rootViewController = vc;
     }
 
     return self;
@@ -48,9 +49,7 @@
 
     [alert addAction:ok];
 
-    UIViewController* rootController = [UIApplication sharedApplication].delegate.window.rootViewController;
-
-    [rootController presentViewController:alert animated:YES completion:nil];
+    [self.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)     webView:(WKWebView*)webView runJavaScriptConfirmPanelWithMessage:(NSString*)message
@@ -79,9 +78,7 @@
         }];
     [alert addAction:cancel];
 
-    UIViewController* rootController = [UIApplication sharedApplication].delegate.window.rootViewController;
-
-    [rootController presentViewController:alert animated:YES completion:nil];
+    [self.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)      webView:(WKWebView*)webView runJavaScriptTextInputPanelWithPrompt:(NSString*)prompt
@@ -115,9 +112,7 @@
         textField.text = defaultText;
     }];
 
-    UIViewController* rootController = [UIApplication sharedApplication].delegate.window.rootViewController;
-
-    [rootController presentViewController:alert animated:YES completion:nil];
+    [self.rootViewController presentViewController:alert animated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
If the web view is presented modally (View, DevApp) then
rootViewController from AppDelegate won't be the topmost view
controller and JS alerts will crash with something along the lines
of "attempted to present ViewController whose view is not in the
window hierarchy”.