### PR TITLE
support cordova-ios-voip-push killed and in drawer

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -129,6 +129,7 @@
         NSDictionary *options = @{
                                   GCDWebServerOption_Port: @(8080),
                                   GCDWebServerOption_BindToLocalhost: @(YES),
+                                  GCDWebServerOption_AutomaticallySuspendInBackground: false,
                                   GCDWebServerOption_ServerName: @"Ionic"
                                   };
         [self.webServer startWithOptions:options error:nil];

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -129,7 +129,7 @@
         NSDictionary *options = @{
                                   GCDWebServerOption_Port: @(8080),
                                   GCDWebServerOption_BindToLocalhost: @(YES),
-                                  GCDWebServerOption_AutomaticallySuspendInBackground: false,
+                                  GCDWebServerOption_AutomaticallySuspendInBackground: @false,
                                   GCDWebServerOption_ServerName: @"Ionic"
                                   };
         [self.webServer startWithOptions:options error:nil];

--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -124,9 +124,9 @@ var iOSExec = function () {
 iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
     var success = status === 0 || status === 1;
     var args = convertMessageToArgsNativeToJs(message);
-    setTimeout(function () {
+    // setTimeout(function () {
     	cordova.callbackFromNative(callbackId, success, status, args, keepCallback); // eslint-disable-line
-    }, 0);
+    // }, 0);
 };
 
 // for backwards compatibility


### PR DESCRIPTION
with this pr if an app have the plugin cordova-ios-voip-push installed on voip push it will trigger wake up app if its killed and run in background and if app is in drawer it'll trigger the on voip push js

ref: https://github.com/meteor/meteor/issues/8112 and https://github.com/Hitman666/cordova-ios-voip-push/issues/1