### PR TITLE
Android improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,13 @@
   "devDependencies": {
     "np": "^2.16.0",
     "sync-cordova-xml": "^0.4.0"
+  },
+  "engines": {
+    "cordovaDependencies": {
+      "2.0.0": {
+        "cordova-android": ">=6.0.0",
+        "cordova-ios": ">=4.0.0-dev"
+      }
+    }
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,7 @@
 	<engines>
         <engine name="cordova-ios" version=">=4.0.0-dev"/>
         <engine name="apple-ios" version=">=9.0"/>
+        <engine name="cordova-android" version=">=6.0.0"/>
 	</engines>
 
   <platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -33,6 +33,7 @@
 
   <platform name="android">
     <config-file target="config.xml" parent="/*">
+      <allow-navigation href="http://localhost:8080/*"/>
       <preference name="webView" value="com.ionicframework.cordova.webview.IonicWebViewEngine" />
     </config-file>
     <source-file src="src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java" target-dir="src/com/ionicframework/cordova/webview" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,9 @@
       <preference name="webView" value="com.ionicframework.cordova.webview.IonicWebViewEngine" />
     </config-file>
     <source-file src="src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java" target-dir="src/com/ionicframework/cordova/webview" />
+    <source-file src="src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java" target-dir="src/com/ionicframework/cordova/webview" />
+    <source-file src="src/android/com/ionicframework/cordova/webview/UriMatcher.java" target-dir="src/com/ionicframework/cordova/webview" />
+    <source-file src="src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java" target-dir="src/com/ionicframework/cordova/webview" />
   </platform>
 
   <!-- ios -->

--- a/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
+++ b/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
@@ -27,12 +27,12 @@ public class AndroidProtocolHandler {
   }
 
   public InputStream openAsset(String path, String assetPath) throws IOException {
-    if (path.startsWith(assetPath + "/_capacitor_")) {
+    if (path.startsWith(assetPath + "/_file_")) {
       if (path.contains("content://")) {
-        String contentPath = path.replace(assetPath + "/_capacitor_/", "content://");
+        String contentPath = path.replace(assetPath + "/_file_/", "content://");
         return context.getContentResolver().openInputStream(Uri.parse(contentPath));
       } else {
-        String filePath = path.replace(assetPath + "/_capacitor_/", "");
+        String filePath = path.replace(assetPath + "/_file_/", "");
         return new FileInputStream(new File(filePath));
       }
     } else {

--- a/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
+++ b/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
@@ -77,6 +77,11 @@ public class AndroidProtocolHandler {
     }
   }
 
+  public InputStream openFile(String filePath) throws IOException  {
+    File localFile = new File(filePath);
+    return new FileInputStream(localFile);
+  }
+
   private static int getFieldId(Context context, String assetType, String assetName)
     throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
     Class<?> d = context.getClassLoader()

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -2,17 +2,16 @@ package com.ionicframework.cordova.webview;
 
 import android.content.Context;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
-import android.webkit.WebViewClient;
 
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.CordovaResourceApi;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CordovaWebViewEngine;
+
 import org.apache.cordova.NativeToJsMessageQueue;
 import org.apache.cordova.PluginManager;
 import org.apache.cordova.engine.SystemWebViewClient;
@@ -44,46 +43,24 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
   public void init(CordovaWebView parentWebView, CordovaInterface cordova, final CordovaWebViewEngine.Client client,
                    CordovaResourceApi resourceApi, PluginManager pluginManager,
                    NativeToJsMessageQueue nativeToJsMessageQueue) {
-    localServer = new WebViewLocalServer(cordova.getActivity(), "localhost", true);
+    localServer = new WebViewLocalServer(cordova.getActivity(), "localhost:8080", true);
     WebViewLocalServer.AssetHostingDetails ahd = localServer.hostAssets("www");
 
-    CordovaWebViewEngine.Client webViewClient = new CordovaWebViewEngine.Client() {
-      public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        return localServer.shouldInterceptRequest(request);
-      }
+    webView.setWebViewClient(new ServerClient(this));
 
-      @Override
-      public void onPageStarted(String newUrl) {
-        Log.d(TAG, "CUSTOM ON PAGE STARTED: " + newUrl);
-        client.onPageStarted(newUrl);
-      }
+    super.init(parentWebView, cordova, client, resourceApi, pluginManager, nativeToJsMessageQueue);
+  }
 
-      @Override
-      public void onPageFinishedLoading(String url) {
-        client.onPageFinishedLoading(url);
-      }
+  private class ServerClient extends SystemWebViewClient
+  {
+    public ServerClient(SystemWebViewEngine parentEngine) {
+      super(parentEngine);
+    }
 
-      @Override
-      public void onReceivedError(int errorCode, String description, String failingUrl) {
-        client.onReceivedError(errorCode, description, failingUrl);
-      }
-
-      @Override
-      public Boolean onDispatchKeyEvent(KeyEvent event) {
-        return client.onDispatchKeyEvent(event);
-      }
-
-      @Override
-      public void clearLoadTimeoutTimer() {
-        client.clearLoadTimeoutTimer();
-      }
-
-      @Override
-      public boolean onNavigationAttempt(String url) {
-        return client.onNavigationAttempt(url);
-      }
-    };
-
-    super.init(parentWebView, cordova, webViewClient, resourceApi, pluginManager, nativeToJsMessageQueue);
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+      return localServer.shouldInterceptRequest(request);
+    }
   }
 }
+

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -24,6 +24,7 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
   public static final String TAG = "IonicWebViewEngine";
 
   private WebViewLocalServer localServer;
+  private String CDV_LOCAL_SERVER;
 
   /** Used when created via reflection. */
   public IonicWebViewEngine(Context context, CordovaPreferences preferences) {
@@ -48,7 +49,10 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     ConfigXmlParser parser = new ConfigXmlParser();
     parser.parse(cordova.getContext());
 
-    localServer = new WebViewLocalServer(cordova.getActivity(), "localhost:8080", true, parser);
+    String port = preferences.getString("WKPort", "8080");
+    CDV_LOCAL_SERVER = "http://localhost:" + port;
+
+    localServer = new WebViewLocalServer(cordova.getActivity(), "localhost:" + port, true, parser);
     WebViewLocalServer.AssetHostingDetails ahd = localServer.hostAssets("www");
 
     webView.setWebViewClient(new ServerClient(this, parser));
@@ -75,8 +79,16 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
       super.onPageStarted(view, url, favicon);
       if (url.equals(parser.getLaunchUrl())) {
         view.stopLoading();
-        view.loadUrl("http://localhost:8080/");
+        view.loadUrl(CDV_LOCAL_SERVER);
       }
+    }
+
+    @Override
+    public void onPageFinished(WebView view, String url) {
+      super.onPageFinished(view, url);
+      view.loadUrl("javascript:(function() { " +
+              "window.WEBVIEW_SERVER_URL = '" + CDV_LOCAL_SERVER + "'" +
+              "})()");
     }
   }
 

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -1,11 +1,13 @@
 package com.ionicframework.cordova.webview;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.util.Log;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 
+import org.apache.cordova.ConfigXmlParser;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.CordovaResourceApi;
@@ -43,23 +45,38 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
   public void init(CordovaWebView parentWebView, CordovaInterface cordova, final CordovaWebViewEngine.Client client,
                    CordovaResourceApi resourceApi, PluginManager pluginManager,
                    NativeToJsMessageQueue nativeToJsMessageQueue) {
-    localServer = new WebViewLocalServer(cordova.getActivity(), "localhost:8080", true);
+    ConfigXmlParser parser = new ConfigXmlParser();
+    parser.parse(cordova.getContext());
+
+    localServer = new WebViewLocalServer(cordova.getActivity(), "localhost:8080", true, parser);
     WebViewLocalServer.AssetHostingDetails ahd = localServer.hostAssets("www");
 
-    webView.setWebViewClient(new ServerClient(this));
+    webView.setWebViewClient(new ServerClient(this, parser));
 
     super.init(parentWebView, cordova, client, resourceApi, pluginManager, nativeToJsMessageQueue);
   }
 
   private class ServerClient extends SystemWebViewClient
   {
-    public ServerClient(SystemWebViewEngine parentEngine) {
+    private ConfigXmlParser parser;
+
+    public ServerClient(SystemWebViewEngine parentEngine, ConfigXmlParser parser) {
       super(parentEngine);
+      this.parser = parser;
     }
 
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
       return localServer.shouldInterceptRequest(request);
+    }
+
+    @Override
+    public void onPageStarted(WebView view, String url, Bitmap favicon) {
+      super.onPageStarted(view, url, favicon);
+      if (url.equals(parser.getLaunchUrl())) {
+        view.stopLoading();
+        view.loadUrl("http://localhost:8080/");
+      }
     }
   }
 

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -62,5 +62,9 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
       return localServer.shouldInterceptRequest(request);
     }
   }
+
+  public void setServerBasePath(String path){
+    localServer.hostFiles(path);
+  }
 }
 

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -166,7 +166,12 @@ public class WebViewLocalServer {
     this.protocolHandler = new AndroidProtocolHandler(context.getApplicationContext());
     if (authority != null) {
       this.authority = authority;
-      this.isLocal = false;
+      if (authority.equals("localhost:8080")) {
+        this.isLocal = true;
+      } else {
+        this.isLocal = false;
+      }
+
     } else {
       this.isLocal = true;
       this.authority = UUID.randomUUID().toString() + "" + knownUnusedAuthority;

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -22,6 +22,8 @@ import android.util.Log;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 
+import org.apache.cordova.ConfigXmlParser;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -67,6 +69,7 @@ public class WebViewLocalServer {
   private boolean isAsset;
   // Whether to route all requests to paths without extensions back to `index.html`
   private final boolean html5mode;
+  private ConfigXmlParser parser;
 
   public String getAuthority() { return authority; }
 
@@ -170,9 +173,10 @@ public class WebViewLocalServer {
     }
   }
 
-  WebViewLocalServer(Context context, String authority, boolean html5mode) {
+  WebViewLocalServer(Context context, String authority, boolean html5mode, ConfigXmlParser parser) {
     uriMatcher = new UriMatcher(null);
     this.html5mode = html5mode;
+    this.parser = parser;
     this.protocolHandler = new AndroidProtocolHandler(context.getApplicationContext());
     if (authority != null) {
       this.authority = authority;
@@ -235,8 +239,10 @@ public class WebViewLocalServer {
     String path = request.getUrl().getPath();
     if (path.equals("/") || (!request.getUrl().getLastPathSegment().contains(".") && html5mode)) {
       InputStream stream;
+      String launchURL = parser.getLaunchUrl();
+      String launchFile = launchURL.substring(launchURL.lastIndexOf("/") + 1, launchURL.length());
       try {
-        String startPath = this.basePath + "/index.html";
+        String startPath = this.basePath + "/" + launchFile;
         if (isAsset) {
           stream = protocolHandler.openAsset(startPath, "");
         } else {
@@ -244,7 +250,7 @@ public class WebViewLocalServer {
         }
 
       } catch (IOException e) {
-        Log.e(TAG, "Unable to open index.html", e);
+        Log.e(TAG, "Unable to open " + launchFile, e);
         return null;
       }
 

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -569,7 +569,11 @@ public class WebViewLocalServer {
       public InputStream handle(Uri url) {
         InputStream stream;
         try {
-          stream = protocolHandler.openFile(basePath + url.getPath());
+          if (url.getPath().startsWith("/_file_/")) {
+            stream = protocolHandler.openFile( url.getPath().replace("/_file_/", ""));
+          } else {
+            stream = protocolHandler.openFile(basePath + url.getPath());
+          }
         } catch (IOException e) {
           Log.e(TAG, "Unable to open asset URL: " + url);
           return null;

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -180,7 +180,7 @@ public class WebViewLocalServer {
     this.protocolHandler = new AndroidProtocolHandler(context.getApplicationContext());
     if (authority != null) {
       this.authority = authority;
-      if (authority.equals("localhost:8080")) {
+      if (authority.startsWith("localhost")) {
         this.isLocal = true;
       } else {
         this.isLocal = false;

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -32,6 +32,7 @@ import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -101,7 +102,14 @@ public class WebViewLocalServer {
       this.charset = charset;
       this.statusCode = statusCode;
       this.reasonPhrase = reasonPhrase;
-      this.responseHeaders = responseHeaders;
+      Map<String, String> tempResponseHeaders;
+      if (responseHeaders == null) {
+        tempResponseHeaders = new HashMap<>();
+      } else {
+        tempResponseHeaders = responseHeaders;
+      }
+      tempResponseHeaders.put("Cache-Control", "no-cache");
+      this.responseHeaders = tempResponseHeaders;
     }
 
     public InputStream handle(WebResourceRequest request) {

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -219,11 +219,6 @@ public class WebViewLocalServer {
   private WebResourceResponse handleLocalRequest(WebResourceRequest request, PathHandler handler) {
     String path = request.getUrl().getPath();
 
-    if (path.equals("/cordova.js")) {
-      return new WebResourceResponse("application/javascript", handler.getEncoding(),
-        handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), null);
-    }
-
     if (path.equals("/") || (!request.getUrl().getLastPathSegment().contains(".") && html5mode)) {
       InputStream stream;
       try {


### PR DESCRIPTION
Add the missing source-files for Android
Remove the handler that return an empty cordova.js as that's only needed for Capacitor, here we want the real cordova.js
Set the webview's webclient to redirect the shouldInterceptRequest to the local server
Set the autority to localhost:8080 as on iOS, but handle it as local requests.
Make the plugin add the allow-navigation for localhost for Android too
