### PR TITLE
Background mode for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+iOS update HTTP server to latest upstream version (GCDwebserve 3.4.2)
+iOS update HTTP server to restart sockets with error state when resuming from background
+iOS enable HTTP server to continue running in background if the webview is running.
+iOS enable Webview to continue running in background. Requires background mode capability enabled in xcode + valid use case as per app store requirements. If your app is not performing valid background tasks it will still be suspended by the OS as usual. As long as valid background tasks are running the webview will continue to function as expected.
+iOS add config.xml options:
+    WKSuspendInBackground - defaults to true, if set to false then the webview and HTTP server will continue to run when the app is in the background or screen is locked
+    WKPort - defaults to 8080, define the port that the HTTP server will listen on
+    WKBind - defaults to localhost, if set to 127.0.0.1 then this IP will be used instead of the localhost hostname for the HTTP server
+    WKAllowRemoteConnect - defaults to false, if set to true the HTTP server will accept connections from remote sources
+
 <a name="2.0.0"></a>
 ### 2.0.0 (PENDING)
 
@@ -8,5 +18,14 @@
 * **BREAKING**: HTTP server is configured to run in HTML5 routing mode (push state) by default.
 * **BREAKING**: File access through the Web View must be served by the HTTP server to avoid security errors in the Web View. Loading files via `file://` is not allowed by the Web View. The HTTP server will serve files via the `_file_` prefix, e.g. `http://localhost:8080/_file_/Users/.../file.png`.
 * `window.Ionic.normalizeURL()` has been deprecated. Use `window.Ionic.WebView.convertFileSrc()`.
+* iOS update HTTP server to latest upstream version (GCDwebserve 3.4.2)
+* iOS update HTTP server to restart sockets with error state when resuming from background
+* iOS enable HTTP server to continue running in background if the webview is running.
+* iOS enable Webview to continue running in background. Requires background mode capability enabled in xcode + valid use case as per app store requirements. If your app is not performing valid background tasks it will still be suspended by the OS as usual. As long as valid background tasks are running the webview will continue to function as expected.
+* iOS add config.xml options:
+    WKSuspendInBackground - defaults to true, if set to false then the webview and HTTP server will continue to run when the app is in the background or screen is locked
+    WKPort - defaults to 8080, define the port that the HTTP server will listen on
+    WKBind - defaults to localhost, if set to 127.0.0.1 then this IP will be used instead of the localhost hostname for the HTTP server
+    WKAllowRemoteConnect - defaults to false, if set to true the HTTP server will accept connections from remote sources
 
 See [Github releases](https://github.com/ionic-team/cordova-plugin-ionic-webview/releases) for earlier changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,8 @@ iOS add config.xml options:
 * iOS update HTTP server to restart sockets with error state when resuming from background
 * iOS enable HTTP server to continue running in background if the webview is running.
 * iOS enable Webview to continue running in background. Requires background mode capability enabled in xcode + valid use case as per app store requirements. If your app is not performing valid background tasks it will still be suspended by the OS as usual. As long as valid background tasks are running the webview will continue to function as expected.
-* iOS add config.xml options:
-    WKSuspendInBackground - defaults to true, if set to false then the webview and HTTP server will continue to run when the app is in the background or screen is locked
-    WKPort - defaults to 8080, define the port that the HTTP server will listen on
-    WKBind - defaults to localhost, if set to 127.0.0.1 then this IP will be used instead of the localhost hostname for the HTTP server
+* iOS add config.xml option WKSuspendInBackground - defaults to true, if set to false then the webview and HTTP server will continue to run when the app is in the background or screen is locked
+* iOS add config.xml option WKPort - defaults to 8080, define the port that the HTTP server will listen on
+* iOS add config.xml option WKBind - defaults to localhost, if set to 127.0.0.1 then this IP will be used instead of localhost for the HTTP server hostname.
 
 See [Github releases](https://github.com/ionic-team/cordova-plugin-ionic-webview/releases) for earlier changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,5 @@ iOS add config.xml options:
     WKSuspendInBackground - defaults to true, if set to false then the webview and HTTP server will continue to run when the app is in the background or screen is locked
     WKPort - defaults to 8080, define the port that the HTTP server will listen on
     WKBind - defaults to localhost, if set to 127.0.0.1 then this IP will be used instead of the localhost hostname for the HTTP server
-    WKAllowRemoteConnect - defaults to false, if set to true the HTTP server will accept connections from remote sources
 
 See [Github releases](https://github.com/ionic-team/cordova-plugin-ionic-webview/releases) for earlier changes.

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -169,6 +169,7 @@
 
     //extend default connection coalescing time when background enabled
     if(!suspendInBackground){
+        NSLog(@"CDVWKWebViewEngine: Suspend in background disabled");
         waitTime = 60;
     }
     

--- a/src/ios/GCDWebServer/Core/GCDWebServer.m
+++ b/src/ios/GCDWebServer/Core/GCDWebServer.m
@@ -155,6 +155,8 @@ static void _ExecuteMainThreadRunLoopSources() {
   dispatch_source_t _source6;
   CFNetServiceRef _registrationService;
   CFNetServiceRef _resolutionService;
+  int ipv4ListeningSocket;
+  int ipv6ListeningSocket;
   DNSServiceRef _dnsService;
   CFSocketRef _dnsSocket;
   CFRunLoopSourceRef _dnsSource;
@@ -434,6 +436,12 @@ static inline NSString* _EncodeBase64(NSString* string) {
                         error:(NSError**)error {
   int listeningSocket = socket(useIPv6 ? PF_INET6 : PF_INET, SOCK_STREAM, IPPROTO_TCP);
   if (listeningSocket > 0) {
+    if (!useIPv6){
+      ipv4ListeningSocket = listeningSocket;
+    } else {
+      ipv6ListeningSocket = listeningSocket;
+    }
+
     int yes = 1;
     setsockopt(listeningSocket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 
@@ -521,12 +529,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
   BOOL bindToLocalhost = [_GetOption(_options, GCDWebServerOption_BindToLocalhost, @NO) boolValue];
   NSUInteger maxPendingConnections = [_GetOption(_options, GCDWebServerOption_MaxPendingConnections, @16) unsignedIntegerValue];
 
-  struct sockaddr_in addr4;
-  bzero(&addr4, sizeof(addr4));
-  addr4.sin_len = sizeof(addr4);
-  addr4.sin_family = AF_INET;
-  addr4.sin_port = htons(port);
-  addr4.sin_addr.s_addr = bindToLocalhost ? htonl(INADDR_LOOPBACK) : htonl(INADDR_ANY);
+  struct sockaddr_in addr4 = [self generateIpv4AddressWithPort:port bindToLocalhost:bindToLocalhost];
   int listeningSocket4 = [self _createListeningSocket:NO localAddress:&addr4 length:sizeof(addr4) maxPendingConnections:maxPendingConnections error:error];
   if (listeningSocket4 <= 0) {
     return NO;
@@ -541,12 +544,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
     }
   }
 
-  struct sockaddr_in6 addr6;
-  bzero(&addr6, sizeof(addr6));
-  addr6.sin6_len = sizeof(addr6);
-  addr6.sin6_family = AF_INET6;
-  addr6.sin6_port = htons(port);
-  addr6.sin6_addr = bindToLocalhost ? in6addr_loopback : in6addr_any;
+  struct sockaddr_in6 addr6 = [self generateAddressWithPort:port bindToLocalhost:bindToLocalhost];
   int listeningSocket6 = [self _createListeningSocket:YES localAddress:&addr6 length:sizeof(addr6) maxPendingConnections:maxPendingConnections error:error];
   if (listeningSocket6 <= 0) {
     close(listeningSocket4);
@@ -711,6 +709,24 @@ static inline NSString* _EncodeBase64(NSString* string) {
 
 #if TARGET_OS_IPHONE
 
+- (BOOL)hasSocketError:(int)socket {
+  int error = 0;
+  socklen_t len = sizeof(error);
+  int retval = getsockopt(socket, SOL_SOCKET, SO_ERROR, &error, &len);
+    
+  if (retval != 0 ) {
+    /* there was a problem getting the error code */
+    GWS_LOG_ERROR(@"error getting socket error code: %s\n", strerror(retval));
+    return YES;
+  }
+   
+  if (error != 0) {
+    GWS_LOG_INFO(@"Socket error: %s on socket %d\n", strerror(error), socket);
+    return YES;
+  }
+  return NO;
+}
+
 - (void)_didEnterBackground:(NSNotification*)notification {
   GWS_DCHECK([NSThread isMainThread]);
   GWS_LOG_DEBUG(@"Did enter background");
@@ -722,12 +738,38 @@ static inline NSString* _EncodeBase64(NSString* string) {
 - (void)_willEnterForeground:(NSNotification*)notification {
   GWS_DCHECK([NSThread isMainThread]);
   GWS_LOG_DEBUG(@"Will enter foreground");
-  if (!_source4) {
+
+  if (_suspendInBackground && !_source4) {
     [self _start:NULL];  // TODO: There's probably nothing we can do on failure
+  }
+ 
+  if ([self isRunning] && ([self hasSocketError:ipv4ListeningSocket] || [self hasSocketError:ipv6ListeningSocket])) {
+    [self _stop];
+    [self _start:nil];
   }
 }
 
 #endif
+
+- (struct sockaddr_in)generateIpv4AddressWithPort:(NSInteger)port bindToLocalhost:(BOOL)bindToLocalhost {
+    struct sockaddr_in addr4;
+    bzero(&addr4, sizeof(addr4));
+    addr4.sin_len = sizeof(addr4);
+    addr4.sin_family = AF_INET;
+    addr4.sin_port = htons(port);
+    addr4.sin_addr.s_addr = bindToLocalhost ? htonl(INADDR_LOOPBACK) : htonl(INADDR_ANY);
+    return addr4;
+}
+
+- (struct sockaddr_in6)generateAddressWithPort:(NSInteger)port bindToLocalhost:(BOOL)bindToLocalhost {
+    struct sockaddr_in6 addr6;
+    bzero(&addr6, sizeof(addr6));
+    addr6.sin6_len = sizeof(addr6);
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_port = htons(port);
+    addr6.sin6_addr = bindToLocalhost ? in6addr_loopback : in6addr_any;
+    return addr6;
+}
 
 - (BOOL)startWithOptions:(NSDictionary*)options error:(NSError**)error {
   if (_options == nil) {
@@ -745,8 +787,8 @@ static inline NSString* _EncodeBase64(NSString* string) {
 #if TARGET_OS_IPHONE
     if (_suspendInBackground) {
       [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
-      [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_willEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
     }
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_willEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
 #endif
     return YES;
   } else {
@@ -762,10 +804,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
 - (void)stop {
   if (_options) {
 #if TARGET_OS_IPHONE
-    if (_suspendInBackground) {
-      [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
-      [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
-    }
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 #endif
     if (_source4) {
       [self _stop];
@@ -1006,6 +1045,24 @@ static inline NSString* _EncodeBase64(NSString* string) {
   NSMutableString* html = [NSMutableString string];
   [html appendString:@"<!DOCTYPE html>\n"];
   [html appendString:@"<html><head><meta charset=\"utf-8\"></head><body>\n"];
+  [html appendString:@"<ul>\n"];
+  for (NSString* file in enumerator) {
+    if (![file hasPrefix:@"."]) {
+      NSString* type = [[enumerator fileAttributes] objectForKey:NSFileType];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      NSString* escapedFile = [file stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+#pragma clang diagnostic pop
+      GWS_DCHECK(escapedFile);
+      if ([type isEqualToString:NSFileTypeRegular]) {
+        [html appendFormat:@"<li><a href=\"%@\">%@</a></li>\n", escapedFile, file];
+      } else if ([type isEqualToString:NSFileTypeDirectory]) {
+        [html appendFormat:@"<li><a href=\"%@/\">%@/</a></li>\n", escapedFile, file];
+      }
+    }
+    [enumerator skipDescendents];
+  }
+  [html appendString:@"</ul>\n"];
   [html appendString:@"</body></html>\n"];
   return [GCDWebServerDataResponse responseWithHTML:html];
 }

--- a/src/ios/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/src/ios/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -48,8 +48,6 @@
 #import "GCDWebServerFileResponse.h"
 #import "GCDWebServerStreamedResponse.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 /**
  *  Check if a custom logging facility should be used instead.
  */
@@ -101,7 +99,7 @@ typedef NS_ENUM(int, GCDWebServerLoggingLevel) {
 };
 
 extern GCDWebServerLoggingLevel GCDWebServerLogLevel;
-extern void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* format, ...) NS_FORMAT_FUNCTION(2, 3);
+extern void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* _Nonnull format, ...) NS_FORMAT_FUNCTION(2, 3);
 
 #if DEBUG
 #define GWS_LOG_DEBUG(...)                                                                                                             \
@@ -154,6 +152,8 @@ extern void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* for
 #endif
 
 #endif
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  GCDWebServer internal constants and APIs.


### PR DESCRIPTION
This is an updated PR which completes the background mode functionality on iOS.

Changelog has been updated with details of all changes.
config.xml values are listed, with their defaults, in the changelog.
GCDWebserver is now also kept alive when WKWebview is kept alive
GCDWebserver fixes for broken sockets when resuming from background suspension are added
GCDWebserver updated to 3.4.2 (latest at 19Jun18) only one small change in this update but may as well be current
Note you must have appropriate background mode capability set in xcode for your app and actually be doing the background activity that matches your capability to stay alive in the background.
Even with this setting your app will still be suspended by the OS when it is idle and the OS wants to reclaim resources and will comply to all normal background mode restrictions.