### PR TITLE
Resolve issue when app is launched in background

### DIFF
--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -124,9 +124,7 @@ var iOSExec = function () {
 iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
     var success = status === 0 || status === 1;
     var args = convertMessageToArgsNativeToJs(message);
-    setTimeout(function () {
-    	cordova.callbackFromNative(callbackId, success, status, args, keepCallback); // eslint-disable-line
-    }, 0);
+    cordova.callbackFromNative(callbackId, success, status, args, keepCallback); // eslint-disable-line
 };
 
 // for backwards compatibility


### PR DESCRIPTION
as per PR https://github.com/ionic-team/cordova-plugin-ionic-webview/pull/58

This change addresses an issue where if the app is launched in the background by a push notification it does not fully launch.  This has 2 consequences.  1) the intended background function that should have been triggered by the notification will not run 2) the next time the user opens the app (after a broken background launch) it will be in a broken state (commonly manifests as hanging at the splashscreen).