### PR TITLE
fix #133 - nil reference to CDV_LOCAL_SERVER

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -160,7 +160,7 @@
     if(bind == nil){
         bind = @"localhost";
     }
- 
+
     //bind to designated port or default to 8080
     int portNumber = [settings cordovaFloatSettingForKey:@"WKPort" defaultValue:8080];
 

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -145,7 +145,7 @@
     self.webServer = [[GCDWebServer alloc] init];
 
     NSString * wwwPath = [[NSBundle mainBundle] pathForResource:@"www" ofType: nil];
-    
+
     [self updateBindPath];
     [self setServerPath:wwwPath];
 
@@ -160,10 +160,10 @@
     if(bind == nil){
         bind = @"localhost";
     }
-    
+ 
     //bind to designated port or default to 8080
     int portNumber = [settings cordovaFloatSettingForKey:@"WKPort" defaultValue:8080];
-    
+
     //set the local server name
     self.CDV_LOCAL_SERVER = [NSString stringWithFormat:@"http://%@:%d", bind, portNumber];
 }
@@ -171,7 +171,7 @@
 -(void)startServer
 {
     NSDictionary * settings = self.commandDelegate.settings;
-    
+
     //bind to designated port or default to 8080
     int portNumber = [settings cordovaFloatSettingForKey:@"WKPort" defaultValue:8080];
 
@@ -764,7 +764,7 @@ static void * KVOContext = &KVOContext;
     if (restart) {
         [self.webServer stop];
     }
-    
+
     __block NSString* basePath = self.CDV_LOCAL_SERVER;
     [self.webServer addGETHandlerForBasePath:@"/" directoryPath:path indexFilename:((CDVViewController *)self.viewController).startPage cacheAge:0 allowRangeRequests:YES];
     [self.webServer addHandlerForMethod:@"GET" pathRegex:@"_file_/" requestClass:GCDWebServerFileRequest.class asyncProcessBlock:^(__kindof GCDWebServerRequest * _Nonnull request, GCDWebServerCompletionBlock  _Nonnull completionBlock) {

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -765,10 +765,10 @@ static void * KVOContext = &KVOContext;
         [self.webServer stop];
     }
 
-    __block NSString* basePath = self.CDV_LOCAL_SERVER;
+    __block NSString* serverUrl = self.CDV_LOCAL_SERVER;
     [self.webServer addGETHandlerForBasePath:@"/" directoryPath:path indexFilename:((CDVViewController *)self.viewController).startPage cacheAge:0 allowRangeRequests:YES];
     [self.webServer addHandlerForMethod:@"GET" pathRegex:@"_file_/" requestClass:GCDWebServerFileRequest.class asyncProcessBlock:^(__kindof GCDWebServerRequest * _Nonnull request, GCDWebServerCompletionBlock  _Nonnull completionBlock) {
-        NSString *urlToRemove = [basePath stringByAppendingString:@"/_file_"];
+        NSString *urlToRemove = [serverUrl stringByAppendingString:@"/_file_"];
         NSString *absUrl = [[[request URL] absoluteString] stringByReplacingOccurrencesOfString:urlToRemove withString:@""];
 
         NSRange range = [absUrl rangeOfString:@"?"];


### PR DESCRIPTION
issue is `self.CDV_LOCAL_SERVER` is set when server is started, not when the `_file_` route is set up.

The change sets up the `CDV_LOCAL_SERVER` path before both so that it's safely accessible in the file handler.