### PR TITLE
return 404 instead of crash

### DIFF
--- a/src/ios/GCDWebServer/Responses/GCDWebServerFileResponse.m
+++ b/src/ios/GCDWebServer/Responses/GCDWebServerFileResponse.m
@@ -79,7 +79,7 @@ static inline NSDate* _NSDateFromTimeSpec(const struct timespec* t) {
 - (instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment mimeTypeOverrides:(NSDictionary*)overrides {
   struct stat info;
   if (lstat([path fileSystemRepresentation], &info) || !(info.st_mode & S_IFREG)) {
-    GWS_DNOT_REACHED();
+    self.statusCode = 404;
     return nil;
   }
 #ifndef __LP64__


### PR DESCRIPTION
`GWS_DNOT_REACHED` causes `halt`. Requesting a file that doesn't exist from the webserver crashes the whole app. It can return a proper http response (404 not found)