### PR TITLE
Fix URL when navigating to local files on iOS

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -434,7 +434,7 @@ static void * KVOContext = &KVOContext;
     if (request.URL.fileURL) {
         NSURL* startURL = [NSURL URLWithString:((CDVViewController *)self.viewController).startPage];
         NSString* startFilePath = [self.commandDelegate pathForResource:[startURL path]];
-        NSURL *url = [[NSURL URLWithString:self.CDV_LOCAL_SERVER] URLByAppendingPathComponent:request.URL.path];
+        NSURL *url = [[NSURL URLWithString:self.CDV_LOCAL_SERVER] URLByAppendingPathComponent:[NSString stringWithFormat:@"/_file_%@", request.URL.path]];
         if ([request.URL.path isEqualToString:startFilePath]) {
             url = [NSURL URLWithString:self.CDV_LOCAL_SERVER];
         }


### PR DESCRIPTION
On iOS [cordova-plugin-code-push](https://github.com/Microsoft/cordova-plugin-code-push) is calling the webview [loadRequest](https://github.com/Microsoft/cordova-plugin-code-push/blob/7ebce4463917b3b653385276463eec1901f36c73/src/ios/CodePush.m#L403) method with a file URL.

Before these changes this URL got converted to `http://localhost:8080/var/mobile/.../index.html` which would return a `404`.

This pull-request converts this URL to: `http://localhost:8080/_file_/var/mobile/.../index.html` so it can actually be handled by the web server.

Please review this carefully because I'm not very familiar with the internals of this plugin and it might have some unintended side-effects.

Related issue: #143 