### PR TITLE
if launch url is external don't load local server

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -114,7 +114,8 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
       super.onPageStarted(view, url, favicon);
-      if (url.equals(parser.getLaunchUrl())) {
+      String launchUrl = parser.getLaunchUrl();
+      if (!launchUrl.contains("http") && url.equals(launchUrl)) {
         view.stopLoading();
         view.loadUrl(CDV_LOCAL_SERVER);
       }


### PR DESCRIPTION
When content tag src attribute is set to a http url (i.e. when using live reload), don't redirect to the local url.

Closes https://github.com/ionic-team/cordova-plugin-ionic/issues/135