### PR TITLE
Handle redirects to the local server on Android

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -120,6 +120,32 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
       return localServer.shouldInterceptRequest(Uri.parse(url));
     }
 
+    @RequiresApi(Build.VERSION_CODES.N)
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+      if (!isLocalServerUrl(request.getUrl())) {
+        return super.shouldOverrideUrlLoading(view, request);
+      }
+
+      view.loadUrl(request.getUrl().toString());
+      return true;
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+      if (!isLocalServerUrl(Uri.parse(url))) {
+        return super.shouldOverrideUrlLoading(view, url);
+      }
+
+      view.loadUrl(url);
+      return true;
+    }
+
+    private boolean isLocalServerUrl(Uri url) {
+      return url.getHost().equals("localhost") && Integer.toString(url.getPort()).equals(preferences.getString("WKPort", "8080"));
+    }
+
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
       super.onPageStarted(view, url, favicon);


### PR DESCRIPTION
On Android, opening an (external) URL in the webview which redirects to the local server (e.g.: `HTTP 301 Location: http://localhost:8080`) results in a **Application Error** `net::ERR_CONNECTION_REFUSED (http://localhost:8080)` (same error as in the screenshot of [#135](https://github.com/ionic-team/cordova-plugin-ionic/issues/135)).

The reason for this seems to be that the [shouldInterceptRequest](https://developer.android.com/reference/android/webkit/WebViewClient#shouldInterceptRequest(android.webkit.WebView,%20android.webkit.WebResourceRequest)) method does not get called for requests initiated by a redirect (although I couldn't find any documentation confirming this).

This pull-request attempts to fix that by explicitly calling the `loadUrl` method for such requests.

This is relevant for authentication workflows where an external authentication service attempts to redirect back to the app/webview (e.g.: `auth0.js`).