### PR TITLE
Wrap callbackFromNative in Promise.resolve

### DIFF
--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -124,7 +124,9 @@ var iOSExec = function () {
 iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
     var success = status === 0 || status === 1;
     var args = convertMessageToArgsNativeToJs(message);
-    cordova.callbackFromNative(callbackId, success, status, args, keepCallback); // eslint-disable-line
+    Promise.resolve().then(function () {
+        cordova.callbackFromNative(callbackId, success, status, args, keepCallback); // eslint-disable-line
+    });
 };
 
 // for backwards compatibility


### PR DESCRIPTION
As on https://github.com/ionic-team/cordova-plugin-ionic-webview/pull/124 the setTimeout was removed, it could cause problems (none reported at the moment, but you never know).

This should protect from those possible problems as it keeps the behaviour the setTimeout used to have (putting the code into a the queue for the next process tick). 

@ghenry22 can you test this and see if keeps working fine in background?

See related [cordova-plugin-wkwebview-engine PR ](https://github.com/apache/cordova-plugin-wkwebview-engine/pull/49)