### PR TITLE
Internal connections only

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ The default port the server will listen on. _You should change this to a random 
 
 The hostname the server will bind to. There aren't a lot of other valid options, but some prefer binding to "127.0.0.1"
 
-#### WKInternalConnectionsOnly (New in 2.1.5)
+#### WKInternalConnectionsOnly (New in 2.2.0)
 
 ```xml
 <preference name="WKInternalConnectionsOnly" value="true" />
 ```
 
-Whether to restrict access to this server to the app itself. Previous versions of this plugin did not restrict access to the app itself. In 2.1.5 and above,
+Whether to restrict access to this server to the app itself. Previous versions of this plugin did not restrict access to the app itself. In 2.2.0 and above,
 the plugin now restricts access to only the app itself.
 
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,53 @@
 
 # Ionic Web View
 
-The Web View plugin for Cordova that is specialized for Ionic apps.
+A Web View plugin for Cordova, focused on Ionic apps (but can be used with any Cordova app).
 
-This is for `cordova-plugin-ionic-webview` @ `2.x`, which uses the latest and greatest features and may not work with all apps. See [Requirements](#requirements) and [Migrating to 2.x](#migrating-to-2x).
+The repo and document are for `cordova-plugin-ionic-webview` @ `2.x`, which uses the new features that may not work with all apps. See [Requirements](#requirements) and [Migrating to 2.x](#migrating-to-2x).
 
 :book: **Documentation**: [https://beta.ionicframework.com/docs/building/webview][ionic-webview-docs]
 
 :mega: **Support/Questions?** Please see our [Support Page][ionic-support] for general support questions. The issues on GitHub should be reserved for bug reports and feature requests.
 
 :sparkling_heart: **Want to contribute?** Please see [CONTRIBUTING.md](https://github.com/ionic-team/cordova-plugin-ionic-webview/blob/master/CONTRIBUTING.md).
+
+### Configuration
+
+This plugin has several configuration options that can be set in `config.xml`. Important: some configuration options should be adjusted for production apps, especially `WKPort`:
+
+#### WKSuspendInBackground
+
+```xml
+<preference name="WKSuspendInBackground" value="false" />
+```
+
+Whether to try to keep the server running when the app is backgrounded. Note: the server will likely be suspended by the OS after a few minutes. In particular, long-lived background tasks are not allowed on iOS outside of select audio and geolocation tasks.
+
+#### WKPort 
+
+```xml
+<preference name="WKPort" value="8080" />
+```
+
+The default port the server will listen on. _You should change this to a random port number!_
+
+#### WKBind
+
+```xml
+<preference name="WKBind" value="localhost" />
+```
+
+The hostname the server will bind to. There aren't a lot of other valid options, but some prefer binding to "127.0.0.1"
+
+#### WKInternalConnectionsOnly (New in 2.1.5)
+
+```xml
+<preference name="WKInternalConnectionsOnly" value="true" />
+```
+
+Whether to restrict access to this server to the app itself. Previous versions of this plugin did not restrict access to the app itself. In 2.1.5 and above,
+the plugin now restricts access to only the app itself.
+
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@
 
 <!-- TODO: remove beta in README.md and CONTRIBUTING.md -->
 
-# Ionic Web View
+# Ionic Web View for Cordova
 
-A Web View plugin for Cordova, focused on Ionic apps (but can be used with any Cordova app).
+A Web View plugin for Cordova, focused on providing the highest performance experience for Ionic apps (but can be used with any Cordova app).
 
-The repo and document are for `cordova-plugin-ionic-webview` @ `2.x`, which uses the new features that may not work with all apps. See [Requirements](#requirements) and [Migrating to 2.x](#migrating-to-2x).
+This plugin defaults to using WKWebView on iOS and the latest evergreen webview on Android. Additionally, this plugin makes it easy to use HTML5 style routing
+that web developers expect for building single-page apps.
+
+Note: This repo and its documentation are for `cordova-plugin-ionic-webview` @ `2.x`, which uses the new features that may not work with all apps. See [Requirements](#requirements) and [Migrating to 2.x](#migrating-to-2x).
 
 :book: **Documentation**: [https://beta.ionicframework.com/docs/building/webview][ionic-webview-docs]
 
@@ -31,7 +34,7 @@ The repo and document are for `cordova-plugin-ionic-webview` @ `2.x`, which uses
 
 :sparkling_heart: **Want to contribute?** Please see [CONTRIBUTING.md](https://github.com/ionic-team/cordova-plugin-ionic-webview/blob/master/CONTRIBUTING.md).
 
-### Configuration
+## Configuration
 
 This plugin has several configuration options that can be set in `config.xml`. Important: some configuration options should be adjusted for production apps, especially `WKPort`:
 
@@ -69,12 +72,12 @@ Whether to restrict access to this server to the app itself. Previous versions o
 the plugin now restricts access to only the app itself.
 
 
-### Requirements
+## Plugin Requirements
 
 * **iOS**: iOS 10+ and `cordova-ios` 4+
 * **Android**: Android 5.0+ and `cordova-android` 6.4+
 
-### Migrating to 2.x
+## Migrating to 2.x
 
 1. Remove and re-add the Web View plugin:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-ionic-webview",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "The official Ionic's WKWebView Engine Plugin",
   "main": "index.js",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
   under the License.
 -->
 
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:rim="http://www.blackberry.com/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-ionic-webview" version="2.1.4">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:rim="http://www.blackberry.com/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-ionic-webview" version="2.2.0">
     <name>cordova-plugin-ionic-webview</name>
     <description>The official Ionic's WKWebView Engine Plugin</description>
     <license>Apache-2.0</license>


### PR DESCRIPTION
This will append the random string to the User Agent and will only allow connections based on the User Agent containing that random string.

Bumped version to 2.2.0 as it's a big enough change, and also other already merged changes like the kit-kat support