### PR TITLE
feat(WebViewLocalServer.java): return 404 error code when a local file is not found

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -202,7 +202,15 @@ public class WebViewLocalServer {
   
   private static WebResourceResponse createWebResourceResponse(String mimeType, String encoding, int statusCode, String reasonPhrase, Map<String, String> responseHeaders, InputStream data) {
     if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      return new WebResourceResponse(mimeType, encoding, statusCode, reasonPhrase, responseHeaders, data);
+      int finalStatusCode = statusCode;
+      try {
+        if (data.available() == 0) {
+          finalStatusCode = 404;
+        }
+      } catch (IOException e) {
+        finalStatusCode = 500;
+      }
+      return new WebResourceResponse(mimeType, encoding, finalStatusCode, reasonPhrase, responseHeaders, data);
     } else {
       return new WebResourceResponse(mimeType, encoding, data);
     }


### PR DESCRIPTION
Currently, the Android version of the plugin always returns http code 200 no matter if the resource
you're trying to get exists or not. The iOS version does return a specific http code for every case. This makes the two implementations inconsistent. This tries to fix that and get the same expected behavior in both of them.

Note that I've used a 500 code in case the call to the `available` method fails. If this is not right let me know and I'll change it. 😉 

BREAKING CHANGE: Until now, the Android part of the plugin was returning a 200 http code even though
the requested file didn't exist. This behavior was inconsistent with the historical behavior of the
iOS webView. This change makes them both work in the same manner but introduces a breaking change
for the current Android users that are expecting a 200 http code no matter what and are testing the
not found error just by checking if the body is null.

fix #216