### PR TITLE
fix serving local file without extension

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -236,6 +236,14 @@ public class WebViewLocalServer {
 
   private WebResourceResponse handleLocalRequest(Uri uri, PathHandler handler) {
     String path = uri.getPath();
+    if (path.startsWith("/_file_")) {
+      InputStream responseStream = new LollipopLazyInputStream(handler, uri);
+      InputStream stream = responseStream;
+      String mimeType = getMimeType(path, stream);
+      return createWebResourceResponse(mimeType, handler.getEncoding(),
+        handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), stream);
+    }
+    
     if (path.equals("/") || (!uri.getLastPathSegment().contains(".") && html5mode)) {
       InputStream stream;
       String launchURL = parser.getLaunchUrl();


### PR DESCRIPTION
Detect the mimetype and serve local files without an extension correctly.

Previously any local file with no extension was served as text/html which broke things and made behaviour inconsistent with iOS.

This applies in the _file_ path only so for persistent local files.  Otherwise the default behaviour still applies.