### PR TITLE
fix: Use a single scheme for all files

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
+++ b/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
@@ -68,14 +68,16 @@ public class AndroidProtocolHandler {
   }
 
   public InputStream openFile(String filePath) throws IOException  {
-    File localFile = new File(filePath);
+    String realPath = filePath.replace(WebViewLocalServer.fileStart, "");
+    File localFile = new File(realPath);
     return new FileInputStream(localFile);
   }
 
   public InputStream openContentUrl(Uri uri)  throws IOException {
+    String realPath = uri.toString().replace(uri.getScheme() + "://" + uri.getHost() + WebViewLocalServer.contentStart, "content:/");
     InputStream stream = null;
     try {
-      stream = context.getContentResolver().openInputStream(Uri.parse(uri.toString().replace(WebViewLocalServer.ionicContentScheme + ":///", "content://")));
+      stream = context.getContentResolver().openInputStream(Uri.parse(realPath));
     } catch (SecurityException e) {
       Log.e(TAG, "Unable to open content URL: " + uri, e);
     }

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -144,8 +144,6 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
       super.onPageFinished(view, url);
       view.loadUrl("javascript:(function() { " +
               "window.WEBVIEW_SERVER_URL = '" + CDV_LOCAL_SERVER + "';" +
-              "window.WEBVIEW_FILE_PREFIX = '" + WebViewLocalServer.ionicFileScheme + "';" +
-              "window.WEBVIEW_CONTENT_PREFIX = '" + WebViewLocalServer.ionicContentScheme + "';" +
               "})()");
     }
   }

--- a/src/ios/CDVWKWebViewEngine.h
+++ b/src/ios/CDVWKWebViewEngine.h
@@ -26,7 +26,6 @@
 @property (nonatomic, strong) NSString * basePath;
 
 extern NSString * const IONIC_SCHEME;
-extern NSString * const IONIC_FILE_SCHEME;
 
 -(void)setServerBasePath:(CDVInvokedUrlCommand*)command;
 -(void)getServerBasePath:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -119,7 +119,6 @@
 NSTimer *timer;
 
 NSString * const IONIC_SCHEME = @"ionic";
-NSString * const IONIC_FILE_SCHEME = @"app-file";
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -242,7 +241,6 @@ NSString * const IONIC_FILE_SCHEME = @"app-file";
     self.handler = [[IONAssetHandler alloc] init];
     [self.handler setAssetPath:[self getStartPath]];
     [configuration setURLSchemeHandler:self.handler forURLScheme:IONIC_SCHEME];
-    [configuration setURLSchemeHandler:self.handler forURLScheme:IONIC_FILE_SCHEME];
 
     // re-create WKWebView, since we need to update configuration
     // remove from keyWindow before recreating
@@ -523,7 +521,7 @@ NSString * const IONIC_FILE_SCHEME = @"app-file";
         NSLog(@"CDVWKWebViewEngine: WK plugin can not be loaded: %@", error);
         return nil;
     }
-    source = [source stringByAppendingString:[NSString stringWithFormat:@"window.WEBVIEW_SERVER_URL = '%@';window.WEBVIEW_FILE_PREFIX = '%@';", self.CDV_LOCAL_SERVER, IONIC_FILE_SCHEME]];
+    source = [source stringByAppendingString:[NSString stringWithFormat:@"window.WEBVIEW_SERVER_URL = '%@';", self.CDV_LOCAL_SERVER]];
 
     return [[WKUserScript alloc] initWithSource:source
                                   injectionTime:WKUserScriptInjectionTimeAtDocumentStart

--- a/src/ios/IONAssetHandler.m
+++ b/src/ios/IONAssetHandler.m
@@ -16,15 +16,20 @@
     NSString * scheme = url.scheme;
 
     if ([scheme isEqualToString:IONIC_SCHEME]) {
-        startPath = self.basePath;
-        if ([stringToLoad isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
-            startPath = [startPath stringByAppendingString:@"/index.html"];
-        } else {
-            startPath = [startPath stringByAppendingString:stringToLoad];
+        NSRange range = [stringToLoad rangeOfString:@"?"];
+        if (range.location != NSNotFound) {
+            stringToLoad = [stringToLoad substringToIndex:range.location];
         }
-    } else if ([scheme isEqualToString:IONIC_FILE_SCHEME]) {
-        if (![stringToLoad isEqualToString:@""]) {
-            startPath = stringToLoad;
+
+        if ([stringToLoad hasPrefix:@"/_app_file_"]) {
+            startPath = [stringToLoad stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
+        } else {
+            startPath = self.basePath;
+            if ([stringToLoad isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
+                startPath = [startPath stringByAppendingString:@"/index.html"];
+            } else {
+                startPath = [startPath stringByAppendingString:stringToLoad];
+            }
         }
     }
 

--- a/src/www/util.js
+++ b/src/www/util.js
@@ -6,15 +6,14 @@ var WebView = {
       return url;
     }
     if (url.startsWith('/')) {
-        return window.WEBVIEW_FILE_PREFIX + "://" + url;
+      return window.WEBVIEW_SERVER_URL + '/_app_file_' + url;
     }
     if (url.startsWith('file://')) {
-      return url.replace('file', window.WEBVIEW_FILE_PREFIX);
+      return window.WEBVIEW_SERVER_URL + url.replace('file://', '/_app_file_');
     }
     if (url.startsWith('content://')) {
-        return url.replace('content://', window.WEBVIEW_CONTENT_PREFIX + ':///');
+      return window.WEBVIEW_SERVER_URL + url.replace('content:/', '/_app_content_');
     }
-
     return url;
   },
   setServerBasePath: function(path) {


### PR DESCRIPTION
Use ionic:// for app assets and local files instead of having multiple schemes based on the file
type

fix #258