### PR TITLE
fix(ios): Fix video playback of files with uppercase extension (#264)

### DIFF
--- a/src/ios/IONAssetHandler.m
+++ b/src/ios/IONAssetHandler.m
@@ -64,7 +64,7 @@ API_AVAILABLE(ios(11.0)){
 -(BOOL) isMediaExtension:(NSString *) pathExtension {
     NSArray * mediaExtensions = @[@"m4v", @"mov", @"mp4",
                            @"aac", @"ac3", @"aiff", @"au", @"flac", @"m4a", @"mp3", @"wav"];
-    if ([mediaExtensions containsObject:pathExtension]) {
+    if ([mediaExtensions containsObject:pathExtension.lowercaseString]) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
Cherry pick for 2.x

fix #260