### PR TITLE
fix(ios): Remove unused code

### DIFF
--- a/src/ios/IONAssetHandler.m
+++ b/src/ios/IONAssetHandler.m
@@ -16,11 +16,6 @@
     NSString * scheme = url.scheme;
 
     if ([scheme isEqualToString:IONIC_SCHEME]) {
-        NSRange range = [stringToLoad rangeOfString:@"?"];
-        if (range.location != NSNotFound) {
-            stringToLoad = [stringToLoad substringToIndex:range.location];
-        }
-
         if ([stringToLoad hasPrefix:@"/_app_file_"]) {
             startPath = [stringToLoad stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
         } else {


### PR DESCRIPTION
The path doesn't include query params, so no need to remove them