### PR TITLE
Fix Google Maps Api V3 

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -118,7 +118,7 @@
 
 NSTimer *timer;
 
-NSString * const IONIC_SCHEME = @"ionic";
+NSString * const IONIC_SCHEME = @"httpsionic";
 
 - (instancetype)initWithFrame:(CGRect)frame
 {


### PR DESCRIPTION
ionic://* is not valid for google maps with security even if ionic://* is enabled on google cloud console.

Serving the app on httpsionic://* works perfect.

Also https://ionic or http://ionic is not a valid scheme