### PR TITLE
Fix(ios): Store / load absolute path on iOS to match android behavior

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -14,6 +14,7 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import java.io.File;
 import org.apache.cordova.ConfigXmlParser;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPreferences;
@@ -76,7 +77,7 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     }
     SharedPreferences prefs = cordova.getActivity().getApplicationContext().getSharedPreferences(IonicWebView.WEBVIEW_PREFS_NAME, Activity.MODE_PRIVATE);
     String path = prefs.getString(IonicWebView.CDV_SERVER_PATH, null);
-    if (!isDeployDisabled() && !isNewBinary() && path != null && !path.isEmpty()) {
+    if (!isDeployDisabled() && !isNewBinary() && path != null && !path.isEmpty() && new File(path).exists()) {
       setServerBasePath(path);
     }
   }

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -104,8 +104,6 @@
 // expose private configuration value required for background operation
 @interface WKWebViewConfiguration ()
 
-@property (setter=_setAlwaysRunsAtForegroundPriority:, nonatomic) bool _alwaysRunsAtForegroundPriority;
-
 @end
 
 
@@ -180,8 +178,6 @@ NSString * const IONIC_SCHEME = @"ionic";
         return configuration;
     }
 
-    //required to stop wkwebview suspending in background too eagerly (as used in background mode plugin)
-    configuration._alwaysRunsAtForegroundPriority = ![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES];
     configuration.allowsInlineMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowInlineMediaPlayback" defaultValue:YES];
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
     configuration.allowsAirPlayForMediaPlayback = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -246,6 +246,8 @@ NSString * const IONIC_SCHEME = @"ionic";
     [self.engineWebView removeFromSuperview];
     WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:self.frame configuration:configuration];
 
+    wkWebView.opaque = false;
+    
     [wkWebView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
 
     wkWebView.UIDelegate = self.uiDelegate;

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -140,11 +140,10 @@ NSString * const IONIC_SCHEME = @"ionic";
 
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     NSString * persistedPath = [userDefaults objectForKey:CDV_SERVER_PATH];
-    if (![self isDeployDisabled] && ![self isNewBinary] && persistedPath && ![persistedPath isEqualToString:@""]) {
-        NSString *libPath = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-        NSString * cordovaDataDirectory = [libPath stringByAppendingPathComponent:@"NoCloud"];
-        NSString * snapshots = [cordovaDataDirectory stringByAppendingPathComponent:@"ionic_built_snapshots"];
-        wwwPath = [snapshots stringByAppendingPathComponent:[persistedPath lastPathComponent]];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+
+    if (![self isDeployDisabled] && ![self isNewBinary] && persistedPath && ![persistedPath isEqualToString:@""] && [fileManager fileExistsAtPath:persistedPath]) {
+        wwwPath = persistedPath;
     }
     self.basePath = wwwPath;
     return wwwPath;
@@ -763,7 +762,7 @@ NSString * const IONIC_SCHEME = @"ionic";
 -(void)persistServerBasePath:(CDVInvokedUrlCommand*)command
 {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-    [userDefaults setObject:[self.basePath lastPathComponent] forKey:CDV_SERVER_PATH];
+    [userDefaults setObject:self.basePath forKey:CDV_SERVER_PATH];
     [userDefaults synchronize];
 }
 


### PR DESCRIPTION
Currently iOS path is stored relative and android path is stored absolute. This prevents me from pointing the server base path to a different directory which I need to do for hot update where the files are downloaded and stored on device storage.

For more details see issue #288 

This change reverts PR #164.

However, I'm not sure why the iOS path switched to relative, but the android one is still absolute?

I'm of the opinion that `persistServerBasePath` should behave identically on iOS and android. This PR makes that happen.

For relative paths the app can ensure to only pass in a relative path or an additional method or parameter could be added.

Edit...

I found issue #157 for more context about the previous PR, and I added a check to see if the update path exists before using it otherwise it falls back to default. I think this partially addresses that issue.

I'm wondering if maybe paths should just be treated like ES6 import paths (relative paths start with `./`). Then, just always treat them as relative to the app path.