### PR TITLE
fix: resolve content uri when Hostname includes port

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
+++ b/src/android/com/ionicframework/cordova/webview/AndroidProtocolHandler.java
@@ -74,7 +74,13 @@ public class AndroidProtocolHandler {
   }
 
   public InputStream openContentUrl(Uri uri)  throws IOException {
-    String realPath = uri.toString().replace(uri.getScheme() + "://" + uri.getHost() + WebViewLocalServer.contentStart, "content:/");
+    Integer port = uri.getPort();
+    String realPath;
+    if (port == -1) {
+      realPath = uri.toString().replace(uri.getScheme() + "://" + uri.getHost() + WebViewLocalServer.contentStart, "content:/");
+    } else {
+      realPath = uri.toString().replace(uri.getScheme() + "://" + uri.getHost() + ":" + port + WebViewLocalServer.contentStart, "content:/");
+    }
     InputStream stream = null;
     try {
       stream = context.getContentResolver().openInputStream(Uri.parse(realPath));


### PR DESCRIPTION
This PR resolves issues with resolving assets. `realPath` string replace fails as the Hostname for example be `localhost:8080`.