### PR TITLE
Fix iOS 12 keyboard dismissal scrolling to top of page

### DIFF
--- a/src/ios/CDVWKWebViewEngine.h
+++ b/src/ios/CDVWKWebViewEngine.h
@@ -24,6 +24,7 @@
 
 @property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
 @property (nonatomic, strong) NSString * basePath;
+@property (nonatomic) CGPoint lastContentOffset;
 
 -(void)setServerBasePath:(CDVInvokedUrlCommand*)command;
 -(void)getServerBasePath:(CDVInvokedUrlCommand*)command;


### PR DESCRIPTION
Commit https://github.com/ionic-team/cordova-plugin-ionic-webview/commit/a67056816ee7fd2b8c74eef1854f2effbd145aea was created to fix issue https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/176 but according to my understanding of the code and testing, it will scroll to the top of the page (`CGPointMake(0, 0)`) regardless of your scroll height, whenever the keyboard will hide.

This is very annoying when filling out forms in a long page, since pressing Done (or doing actions that causes the keyboard to hide, like touching a checkbox input) causes the page to scroll to the top, forcing the user to repeatedly manually scroll down to whatever point they were in the form.

I'm not familiar with Objective C or iOS development at all, so this PR is just code I found and hacked in. I removed `keyboardDisplacementFix` and its use of `timer` and replaced it with what I found here https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/176#issuecomment-455032360. Any feedback or edits would be greatly appreciated.

The end result is that dismissing the keyboard will cause the viewport to animate scrolling down and filling up the whole screen, while keeping the scroll position you had prior to opening the keyboard. (just like you're used to it doing in iOS)

While this PR is an improvement, there is still a bug where manually scrolling or using the input selection buttons while the keyboard is visible (the down and up arrows to the left of Done) and then dismissing the keyboard will scroll the page up to the point where you first opened the keyboard, instead of the natural result of where you currently are scrolled. I hope someone familiar with iOS development will be able to create a commit to fix this.
