### PR TITLE
fix wksuspendinbackground for iOS12.2

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -438,6 +438,7 @@ NSTimer *timer;
 
 - (void)updateSettings:(NSDictionary *)settings
 {
+    NSString* _BGStatus;
     WKWebView* wkWebView = (WKWebView *)_engineWebView;
 
     // By default, DisallowOverscroll is false (thus bounce is allowed)
@@ -454,6 +455,27 @@ NSTimer *timer;
                 }
             }
         }
+    }
+
+    //required to stop wkwebview suspending in background too eagerly (as used in background mode plugin)
+    //updated for iOS 12.2
+    if(![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES]){
+        if (@available(iOS 12.2, *)) {
+            // do stuff for iOS 12.2 and newer
+            NSLog(@"iOS 12.2+ detected");
+            NSString* str = @"YWx3YXlzUnVuc0F0Rm9yZWdyb3VuZFByaW9yaXR5";
+            NSData* data  = [[NSData alloc] initWithBase64EncodedString:str options:0];
+            
+            _BGStatus = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        } else {
+            // do stuff for iOS 12.1 and older
+            NSLog(@"iOS Below 12.2 detected");
+            NSString* str = @"X2Fsd2F5c1J1bnNBdEZvcmVncm91bmRQcmlvcml0eQ==";
+            NSData* data  = [[NSData alloc] initWithBase64EncodedString:str options:0];
+            
+            _BGStatus = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        }
+        NSLog(@"%@", _BGStatus);
     }
 
     wkWebView.configuration.preferences.minimumFontSize = [settings cordovaFloatSettingForKey:@"MinimumFontSize" defaultValue:0.0];

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -179,6 +179,21 @@ NSTimer *timer;
     if (settings == nil) {
         return configuration;
     }
+ 
+    //required to stop wkwebview suspending in background too eagerly (as used in background mode plugin)
+    //updated for iOS 12.2
+    if(![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES]){
+        if (@available(iOS 12.2, *)) {
+            // do stuff for iOS 12.2 and newer
+            NSLog(@"iOS 12.2+ detected");
+            configuration.alwaysRunsAtForegroundPriority = ![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES];
+        } else {
+            // do stuff for iOS 12.1 and older
+            NSLog(@"iOS Below 12.2 detected");
+            configuration._alwaysRunsAtForegroundPriority = ![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES];
+        }
+        NSLog(@"CDVWKWebViewEngine: Suspend in background disabled");
+    }
 
     configuration.allowsInlineMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowInlineMediaPlayback" defaultValue:YES];
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
@@ -457,21 +472,6 @@ NSTimer *timer;
                 }
             }
         }
-    }
-
-    //required to stop wkwebview suspending in background too eagerly (as used in background mode plugin)
-    //updated for iOS 12.2
-    if(![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES]){
-        if (@available(iOS 12.2, *)) {
-            // do stuff for iOS 12.2 and newer
-            NSLog(@"iOS 12.2+ detected");
-            configuration.alwaysRunsAtForegroundPriority = ![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES];
-        } else {
-            // do stuff for iOS 12.1 and older
-            NSLog(@"iOS Below 12.2 detected");
-            configuration._alwaysRunsAtForegroundPriority = ![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES];
-        }
-        NSLog(@"CDVWKWebViewEngine: Suspend in background disabled");
     }
 
     wkWebView.configuration.preferences.minimumFontSize = [settings cordovaFloatSettingForKey:@"MinimumFontSize" defaultValue:0.0];

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -104,6 +104,9 @@
 // expose private configuration value required for background operation
 @interface WKWebViewConfiguration ()
 
+@property (setter=_setAlwaysRunsAtForegroundPriority:, nonatomic) bool _alwaysRunsAtForegroundPriority;
+@property (setter=_setAlwaysRunsAtForegroundPriority:, nonatomic) bool alwaysRunsAtForegroundPriority;
+
 @end
 
 
@@ -438,7 +441,6 @@ NSTimer *timer;
 
 - (void)updateSettings:(NSDictionary *)settings
 {
-    NSString* _BGStatus;
     WKWebView* wkWebView = (WKWebView *)_engineWebView;
 
     // By default, DisallowOverscroll is false (thus bounce is allowed)
@@ -463,19 +465,13 @@ NSTimer *timer;
         if (@available(iOS 12.2, *)) {
             // do stuff for iOS 12.2 and newer
             NSLog(@"iOS 12.2+ detected");
-            NSString* str = @"YWx3YXlzUnVuc0F0Rm9yZWdyb3VuZFByaW9yaXR5";
-            NSData* data  = [[NSData alloc] initWithBase64EncodedString:str options:0];
-            
-            _BGStatus = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            configuration.alwaysRunsAtForegroundPriority = ![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES];
         } else {
             // do stuff for iOS 12.1 and older
             NSLog(@"iOS Below 12.2 detected");
-            NSString* str = @"X2Fsd2F5c1J1bnNBdEZvcmVncm91bmRQcmlvcml0eQ==";
-            NSData* data  = [[NSData alloc] initWithBase64EncodedString:str options:0];
-            
-            _BGStatus = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            configuration._alwaysRunsAtForegroundPriority = ![settings cordovaBoolSettingForKey:@"WKSuspendInBackground" defaultValue:YES];
         }
-        NSLog(@"%@", _BGStatus);
+        NSLog(@"CDVWKWebViewEngine: Suspend in background disabled");
     }
 
     wkWebView.configuration.preferences.minimumFontSize = [settings cordovaFloatSettingForKey:@"MinimumFontSize" defaultValue:0.0];


### PR DESCRIPTION
This PR updates the way that the wksuspendinbackground setting is applied so that it is compatible with iOS 12.2+ and with earlier versions.

As with the previous implementation this does not keep your app running in the background abnormally, it just means that javascript processing isn't immediately terminated.  If you have a valid background capability enabled (ie audio, gps) and your app is active then it will stay alive unless the OS decides to suspend it as it would any other app running in the background.

This functionality is essential for a number of use cases as if javascript processing just stops the second the app is in the background then many apps and types of completely valid functionality fail:
 - authentication that kicks out to an external window (backgrounds the app so callbacks aren't received)
 - play audio in background (cannot catch and act on end of track events or play next track)
 - VoIP apps, cannot trigger app for incoming calls when in background
 - location based services, especially those that require active tracking like sports trackers or apps that use geo-fencing.

I have submitted updates to my own apps already to the app store with no issues or errors encountered.  If you had the wksuspendinbackground value set in config.xml previously this PR will make it work again as expected.