### PR TITLE
feat(LocalProxy - CORS) Proxy requests using the local server

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -218,10 +218,6 @@ public class WebViewLocalServer {
    * @return a response if the request URL had a matching handler, null if no handler was found.
    */
   public WebResourceResponse shouldInterceptRequest(Uri uri, WebResourceRequest request) {
-      if(isLocalProxySource(uri)) {
-        return handleLocalProxyRequest(uri, request);
-      }
-
     PathHandler handler;
     synchronized (uriMatcher) {
       handler = (PathHandler) uriMatcher.match(uri);
@@ -264,69 +260,34 @@ public class WebViewLocalServer {
         URL httpsUrl = new URL(fixedUri);
         URLConnection connection = httpsUrl.openConnection();
         HttpURLConnection httpConnection = (HttpURLConnection)connection;
-        InputStream responseStream = connection.getInputStream();
-
-        Map<String, String> headers = new HashMap<String, String>();
-        for (Map.Entry<String, List<String>> entry : connection.getHeaderFields().entrySet()) {
-            String key = entry.getKey();
-            headers.put(key, entry.getValue().get(0));
-        }
         
-        int code = httpConnection.getResponseCode();
+        Map<String, String> headers = new HashMap<String, String>();
         if(request != null && request.getRequestHeaders().get("Range") != null) {
             String rangeString = request.getRequestHeaders().get("Range");
-            int contentLength = 0;
+            httpConnection.addRequestProperty("Range", rangeString);
+            
+            String contentHeader = connection.getHeaderFields().get("Content-Length").get(0);
 
-            if(responseStream.available() <= 0){
-                contentLength = Integer.parseInt(headers.get("Content-Length"));
-            } else {
-                contentLength = responseStream.available();
-            }
-
+            int contentLength = Integer.parseInt(contentHeader);
             String[] parts = rangeString.split("=");
             String[] streamParts = parts[1].split("-");
             String fromRange = streamParts[0];
             int range = contentLength - 1;
 
             headers.put("Accept-Ranges", "bytes");
-            //headers.put("Content-Length", headers.get("Content-Length"));
+            headers.put("Content-Length", contentHeader);
             headers.put("Content-Range", "bytes " + fromRange + "-" + range + "/" + contentLength);
-
-            /*
-            int contentLength = Integer.parseInt(contentStr[1]);
-            String[] parts = rangeString.split("=");
-            String[] streamParts = parts[1].split("-");
-            String fromRange = streamParts[0];
-            int range = contentLength - 1;
-
-            headers.put("Accept-Ranges", "bytes");
-            headers.put("Content-Length", contentStr[1]);
-            headers.put("Content-Range", "bytes " + fromRange + "-" + range + "/" + contentLength);*/
-
-            code = 206; // Partial content being served
-            //String[] contentLength = request.getRequestHeaders().get("Content-Length").split(",");
-
-            /*int currentRange = Integer.parseInt(rangeString.split("=")[1].replace("-", ""));
-            int totalRange = Integer.parseInt(contentLength[1].trim());
-
-            httpConnection.setRequestProperty("Range", rangeString);
-            //httpConnection.connect();
-
-            headers.put("Content-Length", contentLength[1].trim());
-            headers.put("Content-Range", "bytes " + currentRange + "-" + (totalRange - 1) + "/" + totalRange);*/
         }
 
         // Bypass CORS
         headers.put("Access-Control-Allow-Origin", "*");
         headers.put("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS");
         headers.put("Access-Control-Allow-Headers", "agent, user-data, Access-Control-Allow-Headers, Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers");
-        headers.put("Content-Type", request.getRequestHeaders().get("Content-Type"));
 
         return new WebResourceResponse(connection.getContentType(), connection.getContentEncoding(), 
-                code, httpConnection.getResponseMessage(), headers, responseStream);
+                httpConnection.getResponseCode(), httpConnection.getResponseMessage(), headers, httpConnection.getInputStream());
 
     } catch (Exception e) {
-        //an error occurred
         return null;
     }
   }

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -225,7 +225,7 @@ public class WebViewLocalServer {
       return null;
     }
 
-    if (isLocalFile(uri) || uri.getAuthority().equals(this.authority)) {
+    if (isProxySource(uri) || isLocalFile(uri) || uri.getAuthority().equals(this.authority)) {
       Log.d("SERVER", "Handling local request: " + uri.toString());
       return handleLocalRequest(uri, handler, request);
     } else {

--- a/src/www/util.js
+++ b/src/www/util.js
@@ -14,6 +14,9 @@ var WebView = {
     if (url.startsWith('content://')) {
       return window.WEBVIEW_SERVER_URL + url.replace('content:/', '/_app_content_');
     }
+    if (url.startsWith('proxy://')) {
+      return window.WEBVIEW_SERVER_URL + url.replace('proxy:/', '/_local_proxy_');
+    }
     return url;
   },
   setServerBasePath: function(path) {


### PR DESCRIPTION
## WIP

(Android only, improvements are welcome!)

So far I've seen the ability to proxy requests using a **known** ip, this was not suitable for me.
Now you can perform `http://localhost/_local_proxy_/https://google.com` and it will proxy the request to `https://google.com`, as well as injecting some CORS headers.

Sorry if this is already possible,  could not find it :(

Tested using audio stream links

Related to: https://github.com/ionic-team/cordova-plugin-ionic-webview/pull/230 (iOS only), https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/227 and https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/47