### PR TITLE
Fix for target="_blank" links

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -686,17 +686,21 @@ NSTimer *timer;
     NSString* message = [NSString stringWithFormat:@"Failed to load webpage with error: %@", [error localizedDescription]];
     NSLog(@"%@", message);
 
+    // Ignore 999 domain error as things seem to load fine.
+    if( ! [ error.domain isEqualToString: NSURLErrorDomain ] || error.code != -999 ) {
+
     NSURL* errorUrl = vc.errorURL;
-    if (errorUrl) {
-        errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] relativeToURL:errorUrl];
-        NSLog(@"%@", [errorUrl absoluteString]);
-        [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
-    }
+        if (errorUrl) {
+            errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] relativeToURL:errorUrl];
+            NSLog(@"%@", [errorUrl absoluteString]);
+            [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
+        }
 #ifdef DEBUG
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:message preferredStyle:UIAlertControllerStyleAlert];
-    [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:nil]];
-    [vc presentViewController:alertController animated:YES completion:nil];
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:message preferredStyle:UIAlertControllerStyleAlert];
+        [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:nil]];
+        [vc presentViewController:alertController animated:YES completion:nil];
 #endif
+    }
 }
 
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -759,7 +759,8 @@ NSTimer *timer;
             [scheme isEqualToString:@"facetime"] ||
             [scheme isEqualToString:@"sms"] ||
             [scheme isEqualToString:@"maps"] ||
-            [scheme isEqualToString:@"itms-services"]) {
+            [scheme isEqualToString:@"itms-services"] ||
+            !navigationAction.targetFrame) {
             [[UIApplication sharedApplication] openURL:url];
             decisionHandler(WKNavigationActionPolicyCancel);
         } else {


### PR DESCRIPTION
Fixing target="_blank" links in app to open in external browser window.  Perhaps there is already a way to do this that I'm not aware of, but in my app, links with target="_blank" on iOS devices simply didn't work.  This fix treats those types of links like external links that will open in the iOS browser instead of simply doing nothing.

I'd say more, but the fix is pretty simple / straight forward and was previously discussed in this stack overflow for other cordova plugins:

https://stackoverflow.com/questions/25713069/why-is-wkwebview-not-opening-links-with-target-blank/25853806