### PR TITLE
fix(Android): return proper mimeType for wasm files

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -363,6 +363,8 @@ public class WebViewLocalServer {
         if (path.endsWith(".js")) {
           // Make sure JS files get the proper mimetype to support ES modules
           mimeType = "application/javascript";
+        } else if (path.endsWith(".wasm")) {
+          mimeType = "application/wasm";
         } else {
           mimeType = URLConnection.guessContentTypeFromStream(stream);
         }


### PR DESCRIPTION
When using WebAssembly browser do not recognize .wasm extension on Android.