### PR TITLE
Renaming iOS classes to not conflict with future cordova-ios release

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -66,19 +66,19 @@
         <allow-navigation href="ionic://*"/>
         <preference name="deployment-target" value="11.0"/>
         <feature name="IonicWebView">
-            <param name="ios-package" value="CDVWKWebViewEngine"/>
+            <param name="ios-package" value="IONWKWebViewEngine"/>
         </feature>
-        <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine"/>
+        <preference name="CordovaWebViewEngine" value="IONWKWebViewEngine"/>
     </config-file>
 
     <framework src="WebKit.framework" weak="true"/>
 
-    <header-file src="src/ios/CDVWKWebViewEngine.h"/>
-    <source-file src="src/ios/CDVWKWebViewEngine.m"/>
-    <header-file src="src/ios/CDVWKWebViewUIDelegate.h"/>
-    <source-file src="src/ios/CDVWKWebViewUIDelegate.m"/>
-    <header-file src="src/ios/CDVWKProcessPoolFactory.h"/>
-    <source-file src="src/ios/CDVWKProcessPoolFactory.m"/>
+    <header-file src="src/ios/IONWKWebViewEngine.h"/>
+    <source-file src="src/ios/IONWKWebViewEngine.m"/>
+    <header-file src="src/ios/IONWKWebViewUIDelegate.h"/>
+    <source-file src="src/ios/IONWKWebViewUIDelegate.m"/>
+    <header-file src="src/ios/IONWKProcessPoolFactory.h"/>
+    <source-file src="src/ios/IONWKProcessPoolFactory.m"/>
     <header-file src="src/ios/IONAssetHandler.h"/>
     <source-file src="src/ios/IONAssetHandler.m"/>
     <asset src="src/ios/wk-plugin.js" target="wk-plugin.js"/>

--- a/src/ios/IONAssetHandler.m
+++ b/src/ios/IONAssetHandler.m
@@ -1,6 +1,6 @@
 #import "IONAssetHandler.h"
 #import <MobileCoreServices/MobileCoreServices.h>
-#import "CDVWKWebViewEngine.h"
+#import "IONWKWebViewEngine.h"
 
 @implementation IONAssetHandler
 

--- a/src/ios/IONWKProcessPoolFactory.h
+++ b/src/ios/IONWKProcessPoolFactory.h
@@ -19,7 +19,7 @@
 
 #import <WebKit/WebKit.h>
 
-@interface CDVWKProcessPoolFactory : NSObject
+@interface IONWKProcessPoolFactory : NSObject
 @property (nonatomic, retain) WKProcessPool* sharedPool;
 
 +(instancetype) sharedFactory;

--- a/src/ios/IONWKProcessPoolFactory.m
+++ b/src/ios/IONWKProcessPoolFactory.m
@@ -6,9 +6,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
-
+ 
  http://www.apache.org/licenses/LICENSE-2.0
-
+ 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,15 +17,33 @@
  under the License.
  */
 
+#import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
-#import <Cordova/CDV.h>
+#import "IONWKProcessPoolFactory.h"
 
-@interface CDVWKWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol, WKScriptMessageHandler, WKNavigationDelegate>
+static IONWKProcessPoolFactory *factory = nil;
 
-@property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
-@property (nonatomic, strong) NSString * basePath;
+@implementation IONWKProcessPoolFactory
 
--(void)setServerBasePath:(CDVInvokedUrlCommand*)command;
--(void)getServerBasePath:(CDVInvokedUrlCommand*)command;
++ (instancetype)sharedFactory
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        factory = [[IONWKProcessPoolFactory alloc] init];
+    });
+    
+    return factory;
+}
 
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _sharedPool = [[WKProcessPool alloc] init];
+    }
+    return self;
+}
+
+- (WKProcessPool*) sharedProcessPool {
+    return _sharedPool;
+}
 @end

--- a/src/ios/IONWKWebViewEngine.h
+++ b/src/ios/IONWKWebViewEngine.h
@@ -6,9 +6,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,33 +17,15 @@
  under the License.
  */
 
-#import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
-#import "CDVWKProcessPoolFactory.h"
+#import <Cordova/CDV.h>
 
-static CDVWKProcessPoolFactory *factory = nil;
+@interface IONWKWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol, WKScriptMessageHandler, WKNavigationDelegate>
 
-@implementation CDVWKProcessPoolFactory
+@property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
+@property (nonatomic, strong) NSString * basePath;
 
-+ (instancetype)sharedFactory
-{
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        factory = [[CDVWKProcessPoolFactory alloc] init];
-    });
-    
-    return factory;
-}
+-(void)setServerBasePath:(CDVInvokedUrlCommand*)command;
+-(void)getServerBasePath:(CDVInvokedUrlCommand*)command;
 
-- (instancetype)init
-{
-    if (self = [super init]) {
-        _sharedPool = [[WKProcessPool alloc] init];
-    }
-    return self;
-}
-
-- (WKProcessPool*) sharedProcessPool {
-    return _sharedPool;
-}
 @end

--- a/src/ios/IONWKWebViewUIDelegate.h
+++ b/src/ios/IONWKWebViewUIDelegate.h
@@ -19,7 +19,7 @@
 
 #import <WebKit/WebKit.h>
 
-@interface CDVWKWebViewUIDelegate : NSObject <WKUIDelegate>
+@interface IONWKWebViewUIDelegate : NSObject <WKUIDelegate>
 
 @property (nonatomic, copy) NSString* title;
 

--- a/src/ios/IONWKWebViewUIDelegate.m
+++ b/src/ios/IONWKWebViewUIDelegate.m
@@ -17,9 +17,9 @@
  under the License.
  */
 
-#import "CDVWKWebViewUIDelegate.h"
+#import "IONWKWebViewUIDelegate.h"
 
-@implementation CDVWKWebViewUIDelegate
+@implementation IONWKWebViewUIDelegate
 
 - (instancetype)initWithTitle:(NSString*)title
 {


### PR DESCRIPTION
As Apple will stop accepting submissions of app having any reference of UIWebView in the future and started to warn developers on that aspect, the `cordova-ios` project will have to make a move to WKWebView as default engine.

An issue is already opened https://github.com/apache/cordova-ios/issues/661, as well as a PR from myself (https://github.com/apache/cordova-ios/pull/663) that is embedding the classes of the `cordova-plugin-wkwebview-engine` that share similar names as the one used by some classes in `cordova-plugin-ionic-webview`, provoking duplicate symbols at build time.

This PR includes refactoring of all CDV*.h/.m files of this plugin to ION*.h/.m naming convention instead.
It has been tested on a Ionic project using both forked `cordova-ios` from https://github.com/bpresles/cordova-ios, that include CDVWKWebViewEngine and the present modified `cordova-plugin-ionic-webview` from https://github.com/bpresles/cordova-plugin-ionic-webview and the app is indeed using Ionic WKWebView correctly:

2019-09-04 00:12:42.405396+0200 MyApp[87841:1187296] Using Ionic WKWebView