### PR TITLE
feat(android): proxy service worker requests through local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Default value is `http`
 
 Configures the Scheme the app uses to load the content.
 
+#### ResolveServiceWorkerRequests
+
+```xml
+<preference name="ResolveServiceWorkerRequests" value="true" />
+```
+
+Default value is `false`
+
+Enable to resolve requests made by Service Workers through the local server.
 
 #### MixedContentMode
 

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -83,8 +83,10 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
       setServerBasePath(path);
     }
 
+    boolean setAsServiceWorkerClient = preferences.getBoolean("ResolveServiceWorkerRequests", false);
     ServiceWorkerController controller = null;
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+
+    if (setAsServiceWorkerClient && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
         controller = ServiceWorkerController.getInstance();
         controller.setServiceWorkerClient(new ServiceWorkerClient(){
             @Override

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -80,6 +80,17 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     if (!isDeployDisabled() && !isNewBinary() && path != null && !path.isEmpty()) {
       setServerBasePath(path);
     }
+
+    ServiceWorkerController controller = null;
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+        controller = ServiceWorkerController.getInstance();
+        controller.setServiceWorkerClient(new ServiceWorkerClient(){
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebResourceRequest request) {
+                return localServer.shouldInterceptRequest(request.getUrl(), request);
+            }
+        });
+    }
   }
 
   private boolean isNewBinary() {

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -10,6 +10,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 import android.util.Log;
+import android.webkit.ServiceWorkerController;
+import android.webkit.ServiceWorkerClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;


### PR DESCRIPTION
Currently Service Workers are not able to retrieve files served by the local file server. This
change fixes this, allowing to use PWA-like offline caching utils.

This fixes #410