### PR TITLE
fix(ionassethandler.m): fix startPath is getting null

### DIFF
--- a/src/ios/IONAssetHandler.m
+++ b/src/ios/IONAssetHandler.m
@@ -28,7 +28,7 @@
         if ([stringToLoad hasPrefix:@"/_app_file_"]) {
             startPath = [stringToLoad stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
         } else {
-            startPath = self.basePath;
+            startPath = self.basePath ? self.basePath : @"";
             if ([stringToLoad isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
                 startPath = [startPath stringByAppendingString:@"/index.html"];
             } else {


### PR DESCRIPTION
**Problem**
We are using Ionic inside a bigger project, which is developed natively. To integrate our Ionic part inside the bigger project on iOS, we build a .framework file and distribute that to the developers of the bigger native part.
If it is used that way, Ionic is hangig on splash screen and not loading index.html.

**Solution**
We traced the problem back to the IONAssetHandler. In our case self.basePath is null and stringToLoad (or url.path) contains the fully needed path to index.html. But because the first part of the string concatenation is null, the whole startPath gets null. We fixed this by setting startPath first to an empty string instead of null, if self.basePath has no value.