### PR TITLE
(android): hostname switching

### DIFF
--- a/src/android/com/ionicframework/cordova/webview/IonicWebView.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebView.java
@@ -36,9 +36,10 @@ public class IonicWebView extends CordovaPlugin  {
     } else if (action.equals("setOrigin")) {
       final String hostname = args.getString(0);
       final String scheme = args.getString(1);
+      final JSONArray paths = args.getJSONArray(2);
       cordova.getActivity().runOnUiThread(new Runnable() {
         public void run() {
-          ((IonicWebViewEngine) webView.getEngine()).setOrigin(hostname, scheme);
+          ((IonicWebViewEngine) webView.getEngine()).setOrigin(hostname, scheme, paths);
         }
       });
       return true;

--- a/src/android/com/ionicframework/cordova/webview/IonicWebView.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebView.java
@@ -33,6 +33,15 @@ public class IonicWebView extends CordovaPlugin  {
       editor.putString(CDV_SERVER_PATH, path);
       editor.apply();
       return true;
+    } else if (action.equals("setOrigin")) {
+      final String hostname = args.getString(0);
+      final String scheme = args.getString(1);
+      cordova.getActivity().runOnUiThread(new Runnable() {
+        public void run() {
+          ((IonicWebViewEngine) webView.getEngine()).setOrigin(hostname, scheme);
+        }
+      });
+      return true;
     }
     return false;
   }

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -173,7 +173,10 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     this.scheme = scheme;
     localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme, paths);
     localServer.hostAssets("www");
+    String url = webView.getUrl();
+    String oldHost = CDV_LOCAL_SERVER;
     CDV_LOCAL_SERVER = scheme + "://" + hostname;
-    webView.loadUrl(CDV_LOCAL_SERVER);
+    url = url.replace(oldHost, CDV_LOCAL_SERVER);
+    webView.loadUrl(url);
   }
 }

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -26,6 +26,7 @@ import org.apache.cordova.engine.SystemWebViewClient;
 import org.apache.cordova.engine.SystemWebViewEngine;
 import org.apache.cordova.engine.SystemWebView;
 import java.util.ArrayList;
+import org.json.JSONArray;
 
 public class IonicWebViewEngine extends SystemWebViewEngine {
   public static final String TAG = "IonicWebViewEngine";
@@ -65,7 +66,7 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     scheme = preferences.getString("Scheme", "http");
     CDV_LOCAL_SERVER = scheme + "://" + hostname;
 
-    localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme, new ArrayList());
+    localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme, null);
     localServer.hostAssets("www");
 
     webView.setWebViewClient(new ServerClient(this, parser));
@@ -165,12 +166,12 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     return this.localServer.getBasePath();
   }
 
-  public void setOrigin(String hostname, String scheme) {
+  public void setOrigin(String hostname, String scheme, JSONArray paths) {
 
     ConfigXmlParser parser = new ConfigXmlParser();
     parser.parse(cordova.getActivity());
     this.scheme = scheme;
-    localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme, new ArrayList<String>());
+    localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme, paths);
     localServer.hostAssets("www");
     CDV_LOCAL_SERVER = scheme + "://" + hostname;
     webView.loadUrl(CDV_LOCAL_SERVER);

--- a/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
+++ b/src/android/com/ionicframework/cordova/webview/IonicWebViewEngine.java
@@ -25,6 +25,7 @@ import org.apache.cordova.PluginManager;
 import org.apache.cordova.engine.SystemWebViewClient;
 import org.apache.cordova.engine.SystemWebViewEngine;
 import org.apache.cordova.engine.SystemWebView;
+import java.util.ArrayList;
 
 public class IonicWebViewEngine extends SystemWebViewEngine {
   public static final String TAG = "IonicWebViewEngine";
@@ -64,7 +65,7 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
     scheme = preferences.getString("Scheme", "http");
     CDV_LOCAL_SERVER = scheme + "://" + hostname;
 
-    localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme);
+    localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme, new ArrayList());
     localServer.hostAssets("www");
 
     webView.setWebViewClient(new ServerClient(this, parser));
@@ -162,5 +163,16 @@ public class IonicWebViewEngine extends SystemWebViewEngine {
 
   public String getServerBasePath() {
     return this.localServer.getBasePath();
+  }
+
+  public void setOrigin(String hostname, String scheme) {
+
+    ConfigXmlParser parser = new ConfigXmlParser();
+    parser.parse(cordova.getActivity());
+    this.scheme = scheme;
+    localServer = new WebViewLocalServer(cordova.getActivity(), hostname, true, parser, scheme, new ArrayList<String>());
+    localServer.hostAssets("www");
+    CDV_LOCAL_SERVER = scheme + "://" + hostname;
+    webView.loadUrl(CDV_LOCAL_SERVER);
   }
 }

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -33,6 +33,7 @@ import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.ArrayList;
 
 /**
  * Helper class meant to be used with the android.webkit.WebView class to enable hosting assets,
@@ -64,6 +65,7 @@ public class WebViewLocalServer {
   // Whether to route all requests to paths without extensions back to `index.html`
   private final boolean html5mode;
   private ConfigXmlParser parser;
+  private ArrayList<String> ignorePaths;
 
   public String getAuthority() { return authority; }
 
@@ -163,13 +165,14 @@ public class WebViewLocalServer {
     }
   }
 
-  WebViewLocalServer(Context context, String authority, boolean html5mode, ConfigXmlParser parser, String customScheme) {
+  WebViewLocalServer(Context context, String authority, boolean html5mode, ConfigXmlParser parser, String customScheme, ArrayList<String> ignorePaths) {
     uriMatcher = new UriMatcher(null);
     this.html5mode = html5mode;
     this.parser = parser;
     this.protocolHandler = new AndroidProtocolHandler(context.getApplicationContext());
     this.authority = authority;
     this.customScheme = customScheme;
+    this.ignorePaths = ignorePaths;
   }
 
   private static Uri parseAndVerifyUrl(String url) {
@@ -221,6 +224,12 @@ public class WebViewLocalServer {
     }
     if (handler == null) {
       return null;
+    }
+
+    for(String path : ignorePaths) {
+      if (uri.getPath().contains(path)) {
+        return null;
+      }
     }
 
     if (isLocalFile(uri) || uri.getAuthority().equals(this.authority)) {

--- a/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
+++ b/src/android/com/ionicframework/cordova/webview/WebViewLocalServer.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.ArrayList;
 
+import org.json.JSONArray;
+
 /**
  * Helper class meant to be used with the android.webkit.WebView class to enable hosting assets,
  * resources and other data on 'virtual' http(s):// URL.
@@ -65,7 +67,7 @@ public class WebViewLocalServer {
   // Whether to route all requests to paths without extensions back to `index.html`
   private final boolean html5mode;
   private ConfigXmlParser parser;
-  private ArrayList<String> ignorePaths;
+  private JSONArray ignorePaths;
 
   public String getAuthority() { return authority; }
 
@@ -165,7 +167,7 @@ public class WebViewLocalServer {
     }
   }
 
-  WebViewLocalServer(Context context, String authority, boolean html5mode, ConfigXmlParser parser, String customScheme, ArrayList<String> ignorePaths) {
+  WebViewLocalServer(Context context, String authority, boolean html5mode, ConfigXmlParser parser, String customScheme, JSONArray ignorePaths) {
     uriMatcher = new UriMatcher(null);
     this.html5mode = html5mode;
     this.parser = parser;
@@ -226,9 +228,17 @@ public class WebViewLocalServer {
       return null;
     }
 
-    for(String path : ignorePaths) {
-      if (uri.getPath().contains(path)) {
-        return null;
+    if(this.ignorePaths != null) {
+      for (int i = 0; i < this.ignorePaths.length(); i++) {
+        try {
+          String path = this.ignorePaths.getString(i);
+
+          if (uri.getPath().contains(path)) {
+            return null;
+          }
+        } catch(Exception e) {
+          // Ingore
+        }
       }
     }
 

--- a/src/www/util.js
+++ b/src/www/util.js
@@ -25,8 +25,8 @@ var WebView = {
   persistServerBasePath: function() {
     exec(null, null, 'IonicWebView', 'persistServerBasePath', []);
   },
-  setOrigin: function(hostname, scheme) {
-    exec(null, null, 'IonicWebView', 'setOrigin', [hostname, scheme]);
+  setOrigin: function(hostname, scheme, paths) {
+    exec(null, null, 'IonicWebView', 'setOrigin', [hostname, scheme, paths]);
   }
 }
 

--- a/src/www/util.js
+++ b/src/www/util.js
@@ -24,6 +24,9 @@ var WebView = {
   },
   persistServerBasePath: function() {
     exec(null, null, 'IonicWebView', 'persistServerBasePath', []);
+  },
+  setOrigin: function(hostname, scheme) {
+    exec(null, null, 'IonicWebView', 'setOrigin', [hostname, scheme]);
   }
 }
 


### PR DESCRIPTION
This changes allows the developer on Android to switch the apps hostname at runtime with an app reload. It also allows to whitelist paths to run the app on the same origin as a backend server.