### PR TITLE
feat(iOS): Don't force "UIScrollViewContentInsetAdjustmentNever" (4.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Ionic apps work better if the WKWebView is not scrollable, so the scroll is disa
         npm install @ionic-native/ionic-webview@beta
         ```
 
+## FAQ
+See [FAQ](doc/FAQ.md) for common problems, solutions, and configuration advice.
+
+
 [ionic-homepage]: https://ionicframework.com
 [ionic-docs]: https://ionicframework.com/docs
 [ionic-webview-docs]: https://beta.ionicframework.com/docs/building/webview

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -1,0 +1,14 @@
+# FAQ
+
+## Whitespace above and below content / Content not filling 100% of the screen
+Tags: ios 11, ios 12, ios 13  
+
+**1) You should ensure `viewport-fit=cover` for your html page**  
+In html head include `<meta name="viewport" content="initial-scale=1.0, viewport-fit=cover">`
+
+> About:  
+For iOS11+ this results in the scrollView automatically setting the `ContentInsetAdjustmentBehavior` to `UIScrollViewContentInsetAdjustmentNever` which eliminates the safeInset, (the whitespace), that is applied natively.  
+The safeInset is used to indicate which parts of the screen are partially obscurred (like the little black dip at the top border of the iPhone X).  So if you want to be able to conditionally avoid placing content in that area you can use css and the iOS provided css env() variable [safe-area-inset-<top/bottom/left/rigth>](https://webkit.org/blog/7929/designing-websites-for-iphone-x/).
+
+**2) Apply css style `height:100vh;` to at least the `<html>`, `<body>`, or container element in body.**  
+If this doesn't appear to be working, you can read through [here](https://github.com/apache/cordova-plugin-wkwebview-engine/issues/108) for additional tips on the styling requirements.

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -34,52 +34,6 @@
 #define LAST_BINARY_VERSION_CODE @"lastBinaryVersionCode"
 #define LAST_BINARY_VERSION_NAME @"lastBinaryVersionName"
 
-@implementation UIScrollView (BugIOS11)
-
-+ (void)load {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        Class class = [self class];
-        SEL originalSelector = @selector(init);
-        SEL swizzledSelector = @selector(xxx_init);
-
-        Method originalMethod = class_getInstanceMethod(class, originalSelector);
-        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
-
-        BOOL didAddMethod =
-        class_addMethod(class,
-                        originalSelector,
-                        method_getImplementation(swizzledMethod),
-                        method_getTypeEncoding(swizzledMethod));
-
-        if (didAddMethod) {
-            class_replaceMethod(class,
-                                swizzledSelector,
-                                method_getImplementation(originalMethod),
-                                method_getTypeEncoding(originalMethod));
-        } else {
-            method_exchangeImplementations(originalMethod, swizzledMethod);
-        }
-    });
-}
-
-#pragma mark - Method Swizzling
-
-- (id)xxx_init {
-    id a = [self xxx_init];
-    NSArray *stack = [NSThread callStackSymbols];
-    for(NSString *trace in stack) {
-        if([trace containsString:@"WebKit"]) {
-            [a setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
-            break;
-        }
-    }
-    return a;
-}
-
-@end
-
-
 @interface CDVWKWeakScriptMessageHandler : NSObject <WKScriptMessageHandler>
 
 @property (nonatomic, weak, readonly) id<WKScriptMessageHandler>scriptMessageHandler;
@@ -262,8 +216,6 @@ NSTimer *timer;
     // remove from keyWindow before recreating
     [self.engineWebView removeFromSuperview];
     WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:self.frame configuration:configuration];
-
-    [wkWebView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
 
     wkWebView.UIDelegate = self.uiDelegate;
     self.engineWebView = wkWebView;


### PR DESCRIPTION
Sister PR #530 for 2.x

While spending ridiculous amounts of time on PR #!!!, (and all it's related threads), I also looked into the code that is forcing UIScrollViewContentInsetAdjustmentNever mode.

For most users this behavior would be fine, but after reading @dpogue comments [here](https://github.com/apache/cordova-plugin-wkwebview-engine/pull/107#issue-298658969) and [through this thread](https://github.com/apache/cordova-plugin-wkwebview-engine/issues/108) I am convinced that forcing this behavior is incorrect.  (Especially, when users can control this themselves via html `viewport-fit=cover`.)  
**I have added *doc/FAQ.md* which describes this in more detail.**  
The helloWorld Cordova project and the ionic tutorial project uses `viewport-fit=cover` by default.  So this should be pretty standard for cordova users.

---

There are 2 pieces of code which force `UIScrollViewContentInsetAdjustmentNever`.  

### 1. Originally committed on 2017-09-19 with the message:
Adjust scroll view behavior for iOS 11
```objc
[wkWebView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
```

### 2. Originally committed on 2017-09-20 with the message:
> Fix for iOS11 initial scroll
<details>
<summary>Code... Swizzling</summary>

```objc

@implementation UIScrollView (BugIOS11)

#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000

+ (void)load {
    if (@available(iOS 11.0, *)) {
        static dispatch_once_t onceToken;
        dispatch_once(&onceToken, ^{
            Class class = [self class];
            SEL originalSelector = @selector(init);
            SEL swizzledSelector = @selector(xxx_init);

            Method originalMethod = class_getInstanceMethod(class, originalSelector);
            Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);

            BOOL didAddMethod =
            class_addMethod(class,
                            originalSelector,
                            method_getImplementation(swizzledMethod),
                            method_getTypeEncoding(swizzledMethod));

            if (didAddMethod) {
                class_replaceMethod(class,
                                    swizzledSelector,
                                    method_getImplementation(originalMethod),
                                    method_getTypeEncoding(originalMethod));
            } else {
                method_exchangeImplementations(originalMethod, swizzledMethod);
            }
        });
    }
}

#endif

#pragma mark - Method Swizzling

- (id)xxx_init {
    id a = [self xxx_init];
    if (@available(iOS 11.0, *)) {
        NSArray *stack = [NSThread callStackSymbols];
        for(NSString *trace in stack) {
            if([trace containsString:@"WebKit"]) {
                [a setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
                break;
            }
        }
    }
    return a;
}

@end
```

</details>

---

Honestly not really sure why *both* of them exist.  But, since they are committed within a day of each other, they were both probably just hurrying to fix the *temporary* ios 11 bug that prevented `viewport-fit=cover` from working ([CB-12886](https://issues.apache.org/jira/browse/CB-12886)).  

Since it appears the root issue has been solved and released by Apple (at least for iOS 12 and 13 according to my testing), these pieces of code are no longer necessary.  (I did not test iOS 11 because I don't have an 11 device, which is because no Apple devices have a max OS of 11, so it should be fairly safe to ignore.)

---

## Environment
I have been testing with:
* Xcode 10.2

I have been testing on these devices:
* iPad mini 2, iOS 12.4.5 (real)
* iPhone 6s, iOS 13.3.1 (real)
* iPhone X, iOS 12.2 (emulator)

I have been testing with these projects:  

[modified ionic tutorial](https://github.com/Lindsay-Needs-Sleep/ionic-tutorial)
* cordova-plugin-ionic-webview 4.x
* cordova-plugin-ionic-keyboard / NO cordova-plugin-ionic-keyboard

[modified cordova helloWorld](https://github.com/Lindsay-Needs-Sleep/cordova-helloworld)
* NO cordova-plugin-ionic-keyboard

### I have also tested the 2.x sister PR #530 (which has identical changes basically) with this project:
cordova
* cordova-plugin-ionic-webview 2.x

## Summary
Removing these pieces of code:
* Allow user control of whether ios natively applies the safe inset or not
* Brings cordova-plugin-ionic-webview closer inline with its progenitor, cordova-plugin-wkwebview-engine