### PR TITLE
fix(ios): avoid app scrolling to top on keyboard hide

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -301,12 +301,15 @@
      selector:@selector(onAppWillEnterForeground:)
      name:UIApplicationWillEnterForegroundNotification object:nil];
 
-    // For keyboard dismissal leaving viewport shifted (can potentially be removed when apple releases the fix for the issue discussed here: https://github.com/apache/cordova-ios/issues/417#issuecomment-423340885)
-    [[NSNotificationCenter defaultCenter]
-     addObserver:self
-     selector:@selector(keyboardWillHide)
-     name:UIKeyboardWillHideNotification object:nil];
-
+    // If less than ios 13.4
+    if (@available(iOS 13.4, *)) {} else {
+        // For keyboard dismissal leaving viewport shifted (can potentially be removed when apple releases the fix for the issue discussed here: https://github.com/apache/cordova-ios/issues/417#issuecomment-423340885)
+        // Apple has released a fix in 13.4, but not in 12.x (as of 12.4.6)
+        [[NSNotificationCenter defaultCenter]
+        addObserver:self
+        selector:@selector(keyboardWillHide)
+        name:UIKeyboardWillHideNotification object:nil];
+    }
 
     NSLog(@"Using Ionic WKWebView");
 


### PR DESCRIPTION
Sister PR for 2.x: PR #532

---

The history of the keyboard dismissal problems are kind of messy so here we go:

### 1)
The main bug that started this all is reported here:
* [cordova-plugin-ionic-webview #176](https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/176)
* [cordova-plugin-wkwebview-engine #71](https://github.com/apache/cordova-plugin-wkwebview-engine/issues/71)
* [cordova-ios #417](https://github.com/apache/cordova-ios/issues/417) Which best identifies the problem.


To summarize: Apple did something and broke a part of WKWebView for iOS 12 and 13.  The problem occurs when the keyboard is dismissed.  **After dismissal the bottom part of the page has a white unused portion / the content behind the keyboard becomes unusable.**

The issue is truly an apple problem.  So this PR, and the previously accepted PR #201, should not be required if apple ever actually releases the fix.  (The fix has been completed already apparently).  
You can see the apple bug report links [here](https://github.com/apache/cordova-ios/issues/417#issuecomment-423340885).

### 2)
PR #179 and PR #201 attempt to fix this problem.

* PR #179 is denied.  
* PR #201 is accepted.  

### 3) 
Unfortunately, PR #201 introduces another a secondary bug, #399.  
Now, when the keyboard is dismissed the screen scrolls all the way back to the top. 
(Also reported in [cordova-plugin-ionic-keyboard #84](https://github.com/ionic-team/cordova-plugin-ionic-keyboard/issues/84).)

### 4)
To fix the scroll to top issue we have PR #342.  Unfortunately, this introduces another (less problematic [bug](https://github.com/ionic-team/cordova-plugin-ionic-webview/pull/342#issuecomment-588044959)): the view now "jumps" a little when moving between text fields.

---

# Proposed Solution
Modify the changes from PR #201 using inspiriration from PR #342.  

In KeyboardWillHide event:
* Detect when the presence of the keyboard has allowed the user to scroll further than they would have been able to without the keyboard.  (aka. If there will be whitespace at the bottom when the keyboard goes down)
* If in the situation above, do some math to calculate the maximum allowed offset, and set the view to that.  This causes the view to move into place properly.  (So no empty whitespace or unusable portion of the view.)

## Environment
I have been testing with:
* Xcode 10.2

I have been testing on these devices:
* iPad mini 2, iOS 12.4.5 (real)
* iPhone 6s, iOS 13.3.1 (real)
* iPhone X, iOS 12.2 (emulator)

And these projects:

[modified ionic tutorial](https://github.com/Lindsay-Needs-Sleep/ionic-tutorial)
* cordova-plugin-ionic-webview 4.x
* cordova-plugin-ionic-keyboard / NO cordova-plugin-ionic-keyboard

[modified cordova helloWorld](https://github.com/Lindsay-Needs-Sleep/cordova-helloworld)
* NO cordova-plugin-ionic-keyboard

**I have also tested this change with, and without, the changes in PR #531**

### I have also tested the 2.x sister PR #532 (which has identical changes basically) with this project:
cordova
* cordova-plugin-ionic-webview 2.x
* no keyboard plugins
* Lots of other plugins that shouldn't matter


## Summary

Fixes:
* #399
* #509
* [cordova-plugin-ionic-keyboard #84](https://github.com/ionic-team/cordova-plugin-ionic-keyboard/issues/84)

**Compatible with PR #531.**

# Alternate Solution

* Remove all changes from PR #201 (the keyboard event listeners)
* And recommend that users use [cordova-plugin-wkkeyboardfix](https://github.com/AyogoHealth/cordova-plugin-wkkeyboardfix) until Apple releases the fix in an iOS update

Pros:
* Less code muddling on our side (cleaner history)

Cons:
* Apparently the plugin *may* result in a rejection

(tested this plugin on the ionic and cordova project for 4.x, and cordova for 2.x)

Since this plugin has already fixed this issue, I suppose it is probably better to just fix the fix at this point rather than this.