### PR TITLE
Set AllowLinkPreview default value to true

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -487,7 +487,7 @@ NSTimer *timer;
     }
 
     wkWebView.configuration.preferences.minimumFontSize = [settings cordovaFloatSettingForKey:@"MinimumFontSize" defaultValue:0.0];
-    wkWebView.allowsLinkPreview = [settings cordovaBoolSettingForKey:@"AllowLinkPreview" defaultValue:NO];
+    wkWebView.allowsLinkPreview = [settings cordovaBoolSettingForKey:@"AllowLinkPreview" defaultValue:YES];
     wkWebView.scrollView.scrollEnabled = [settings cordovaBoolSettingForKey:@"ScrollEnabled" defaultValue:NO];
     wkWebView.allowsBackForwardNavigationGestures = [settings cordovaBoolSettingForKey:@"AllowBackForwardNavigationGestures" defaultValue:NO];
 }


### PR DESCRIPTION
I believe a few issues rise from the default being `NO`:

1. Since iOS 13.4 (a few days ago), text selection doesn’t work anymore if `wkWebView.allowsLinkPreview` is false.
2. Probably since iOS ~13.0 or when most 3D touch gestures were changed for long-press gestures (i.e. moving cursor, moving folders, link previews, etc), long-press on links doesn’t do anything at all. IINM, it used to show a context menu (w/ Copy link, Share). Looks like these actions are now tied to the link preview UI.

Hard to say whether that is a side effect of something that has changed or if that’s an actual bug on Apple’s end, but since the link between `allowsLinkPreview` and text selection throughout the app isn’t very obvious and arguably unexpected, I think it would be safer to enable it by default.

Cordova’s own implementation of WKWebView (not published yet) has this enabled by default: [CDVWebViewEngine.m#L366](https://github.com/apache/cordova-ios/blob/20248c196d35c9b8390dbbd2953f9bc1191b6c6d/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m#L366)