### PR TITLE
feat(ios): set AllowBackNavigationGestures dynamically from JavaScript

### DIFF
--- a/src/ios/CDVWKWebViewEngine.h
+++ b/src/ios/CDVWKWebViewEngine.h
@@ -27,5 +27,6 @@
 
 -(void)setServerBasePath:(CDVInvokedUrlCommand*)command;
 -(void)getServerBasePath:(CDVInvokedUrlCommand*)command;
+-(void)setAllowBackNavigationGestures:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -802,6 +802,17 @@
     [userDefaults synchronize];
 }
 
+-(void)setAllowBackNavigationGestures:(CDVInvokedUrlCommand*)command
+{
+     id value = [command argumentAtIndex:0];
+     if (!([value isKindOfClass:[NSNumber class]])) {
+         value = [NSNumber numberWithBool:NO];
+     }
+
+     WKWebView* wkWebView = (WKWebView*)_engineWebView;
+     wkWebView.allowsBackForwardNavigationGestures = [value boolValue];
+}
+
 @end
 
 #pragma mark - CDVWKWeakScriptMessageHandler

--- a/src/www/util.js
+++ b/src/www/util.js
@@ -24,6 +24,9 @@ var WebView = {
   },
   persistServerBasePath: function() {
     exec(null, null, 'IonicWebView', 'persistServerBasePath', []);
+  },
+  setAllowBackNavigationGestures: function(allow) {
+    exec(null, null, 'IonicWebView', 'setAllowBackNavigationGestures', [allow]);
   }
 }
 


### PR DESCRIPTION
Currently there is no way to set `AllowBackNavigationGestures` in Javascript except set this preference in config.xml

For those need to set this preference dynamically in cordova project, this might be useful