### PR TITLE
feat(ios): allow enabling fullscreen functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Whether to use a dark styled keyboard on iOS
 
 Ionic apps work better if the WKWebView is not scrollable, so the scroll is disabled by default, but can be enabled with this preference. This only affects the main ScrollView of the WKWebView, so only affects the body, not other scrollable components.
 
+#### WKFullScreenEnabled
+
+```xml
+<preference name="WKFullScreenEnabled" value="true" />
+```
+
+Default value is `false`.
+
+Whether to enable fullscreen functions in WKWebView. If enabled, the functions document.documentElement.webkitRequestFullscreen and document.documentElement.webkitRequestFullScreen will be available.
+
 ## Plugin Requirements
 
 * **Cordova CLI**: 7.1.0+

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -200,6 +200,9 @@
         ) {
         userAgent = [NSString stringWithFormat:@"%@ %@", userAgent, [settings cordovaSettingForKey:@"AppendUserAgent"]];
     }
+    if([settings cordovaBoolSettingForKey:@"WKFullScreenEnabled" defaultValue:NO]){
+        [configuration.preferences setValue:[NSNumber numberWithBool:YES] forKey:@"fullScreenEnabled"];
+    }
     configuration.applicationNameForUserAgent = userAgent;
     configuration.allowsInlineMediaPlayback = [settings cordovaBoolSettingForKey:@"AllowInlineMediaPlayback" defaultValue:YES];
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];


### PR DESCRIPTION
With this change, developers can enable the fullscreen API in their apps. This can be useful for example to make iframes fullscreen.

Related issue: https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/350